### PR TITLE
feat: allow overriding WSD model via WSD_MODEL env var

### DIFF
--- a/wsd/masked_language_model.py
+++ b/wsd/masked_language_model.py
@@ -1,9 +1,14 @@
+import os
 import time
 from dataclasses import dataclass
 from functools import cache
 
 import torch
 from transformers import AutoModelForMaskedLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
+
+# Allow overriding the model source (e.g. a local checkpoint directory) for
+# benchmarking or evaluation without editing call sites.
+_DEFAULT_MODEL = os.environ.get("WSD_MODEL", "sign/ModernBERT-Large-Instruct-WSD")
 
 
 class PromptMaskError(ValueError):
@@ -27,7 +32,7 @@ class UnmaskResult:
 
 
 @cache
-def load_model(model_name: str = "sign/ModernBERT-Large-Instruct-WSD") -> ModelComponents:
+def load_model(model_name: str = _DEFAULT_MODEL) -> ModelComponents:
     if torch.cuda.is_available():
         device = "cuda"
     elif torch.backends.mps.is_available():


### PR DESCRIPTION
## Summary
- Adds `WSD_MODEL` environment variable as the default for `load_model()` in `wsd/masked_language_model.py`.
- Lets benchmarks/evals point at a local checkpoint directory without editing call sites.

## Test plan
- [ ] `WSD_MODEL=/path/to/checkpoint python -m wsd.benchmark` loads the local checkpoint.
- [ ] Unset `WSD_MODEL` still loads the default `sign/ModernBERT-Large-Instruct-WSD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to model selection defaults; primary risk is accidentally using the wrong checkpoint in an environment, not code correctness or security.
> 
> **Overview**
> `load_model()` now defaults to an env-configurable model source by introducing `_DEFAULT_MODEL`, which reads `WSD_MODEL` and falls back to `sign/ModernBERT-Large-Instruct-WSD`.
> 
> This enables benchmarks/evals to point at a different Hugging Face model ID or local checkpoint directory without changing call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4928ecde09f9473a383cd28c36865d9ba3823231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The default model can now be customized through an environment variable, allowing you to switch between different models without code modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->