### PR TITLE
feat: share mark_word_in_sentence between prompt and benchmark

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -25,7 +25,13 @@ from transformers import (
     TrainingArguments,
 )
 
-from wsd.prompt import Definition, create_multiple_choice_prompt, get_option_letter
+from wsd.prompt import (
+    Definition,
+    WordNotFoundError,
+    create_multiple_choice_prompt,
+    get_option_letter,
+    mark_word_in_sentence,
+)
 
 # Constants
 DEFAULT_MODEL = "answerdotai/ModernBERT-Large-Instruct"
@@ -62,28 +68,6 @@ class TrainingExample:
     correct_synset_id: str
     correct_answer_letter: str
     prompt: str
-
-
-def mark_word_in_sentence(sentence: str, word: str) -> str:
-    """
-    Mark the first occurrence of word in sentence with asterisks.
-
-    Args:
-        sentence: The sentence containing the word
-        word: The word to mark
-
-    Returns:
-        The sentence with the first occurrence of word marked with asterisks
-    """
-    lower_sentence = sentence.lower()
-    lower_word = word.lower()
-
-    start_idx = lower_sentence.find(lower_word)
-    if start_idx == -1:
-        return sentence
-
-    end_idx = start_idx + len(word)
-    return sentence[:start_idx] + "*" + sentence[start_idx:end_idx] + "*" + sentence[end_idx:]
 
 
 def create_examples_for_synset(
@@ -136,7 +120,13 @@ def create_examples_for_synset(
 
     # Create one example for each sentence
     for sentence in synset["examples"]:
-        marked_sentence = mark_word_in_sentence(sentence, word)
+        try:
+            marked_sentence = mark_word_in_sentence(sentence, word)
+        except WordNotFoundError:
+            # Skip sentences where the target word can't be located as a whole
+            # word. The previous implementation silently returned the sentence
+            # unmarked, which produced training examples with no marked span.
+            continue
 
         # Find correct answer after shuffling
         correct_original_idx = synset_to_definition[synset_id]
@@ -192,7 +182,11 @@ def create_none_of_above_example(
     # Pick a random synset and sentence from a different POS
     chosen_synset = random.choice(other_pos_synsets)
     chosen_sentence = random.choice(chosen_synset["examples"])
-    marked_sentence = mark_word_in_sentence(chosen_sentence, word)
+    try:
+        marked_sentence = mark_word_in_sentence(chosen_sentence, word)
+    except WordNotFoundError:
+        # The chosen sentence doesn't contain the target word as a whole word.
+        return None
 
     # Collect definitions only from the most frequent POS tag
     frequent_pos_definitions = []

--- a/wsd/benchmark.py
+++ b/wsd/benchmark.py
@@ -1,10 +1,10 @@
 import random
-import re
 from dataclasses import dataclass
 
 import wn
 from tqdm import tqdm
 
+from wsd.prompt import WordNotFoundError, mark_word_in_sentence
 from wsd.word_sense_disambiguation import (
     DisambiguationInput,
     WordQuery,
@@ -47,10 +47,11 @@ def collect_wordnet_examples():
         for word in synset.words():
             for form in word.forms():
                 for example in examples:
-                    regex_form = r'\b' + re.escape(form) + r'\b'
-                    if re.search(regex_form, example, re.IGNORECASE):
-                        marked_text = re.sub(regex_form, r'*\g<0>*', example, flags=re.IGNORECASE)
-                        yield WordNetExample(synset_id, form, word.lemma(), word.pos, marked_text)
+                    try:
+                        marked_text = mark_word_in_sentence(example, form)
+                    except WordNotFoundError:
+                        continue
+                    yield WordNetExample(synset_id, form, word.lemma(), word.pos, marked_text)
 
 if __name__ == "__main__":
     examples = collect_wordnet_examples()

--- a/wsd/prompt.py
+++ b/wsd/prompt.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 
 NONE_OF_THE_ABOVE = "none of the above"
@@ -7,6 +8,39 @@ class OptionLetterIndexError(ValueError):
     """Raised when index is too large for option letter"""
     def __init__(self, index: int):
         super().__init__(f"Index too large for option letter {index}")
+
+
+class WordNotFoundError(ValueError):
+    """Raised when *word* cannot be found in *sentence* with word boundaries."""
+    def __init__(self, word: str, sentence: str):
+        super().__init__(f"Word {word!r} not found with word boundaries in sentence: {sentence!r}")
+        self.word = word
+        self.sentence = sentence
+
+
+def mark_word_in_sentence(sentence: str, word: str) -> str:
+    """Mark the first word-boundary occurrence of *word* in *sentence* with asterisks.
+
+    Case-insensitive. Uses regex word boundaries so the match does not fire
+    inside longer words ("bank" does not match inside "bankrupt"). Exactly
+    one span is marked (the first match), so the output always contains
+    exactly one ``*...*`` pair.
+
+    Raises ``WordNotFoundError`` if no word-boundary match is found, or if
+    *sentence* already contains an asterisk (which would be ambiguous with
+    our marker character).
+    """
+    if "*" in sentence:
+        raise WordNotFoundError(word, sentence)
+    pattern = r"\b" + re.escape(word) + r"\b"
+    match = re.search(pattern, sentence, flags=re.IGNORECASE)
+    if match is None:
+        raise WordNotFoundError(word, sentence)
+    start, end = match.span()
+    marked = sentence[:start] + "*" + sentence[start:end] + "*" + sentence[end:]
+    # Invariant: exactly one marked span (two asterisks) in the output.
+    assert marked.count("*") == 2, marked
+    return marked
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Introduces `mark_word_in_sentence` (+ `WordNotFoundError`) in `wsd/prompt.py` as the single source of truth for marking the target word with `*...*`.
- Uses regex word boundaries (so `bank` does not match inside `bankrupt`) and marks only the first occurrence — output always contains exactly one marked span.
- `wsd/benchmark.py` now calls the shared helper instead of inlining its own regex. Skip-on-miss behavior is preserved by catching `WordNotFoundError`.

Note: `benchmark.py` previously marked *every* occurrence via `re.sub`; the shared helper marks only the first, consistent with the rest of the pipeline.

## Test plan
- [ ] `python -m wsd.benchmark` runs end-to-end with examples collected as before.
- [ ] Unit cover: `mark_word_in_sentence` raises `WordNotFoundError` on miss, rejects pre-marked sentences, respects word boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how sentences are marked and filtered for both training data generation and benchmarking, which can alter dataset composition and evaluation results. Logic is localized and non-security-sensitive, but mistakes could silently drop or mis-mark many examples.
> 
> **Overview**
> Centralizes `*word*` marking into `wsd.prompt.mark_word_in_sentence` and introduces `WordNotFoundError` to explicitly signal when a whole-word, boundary-aware match cannot be found (or when the sentence is already marked).
> 
> Updates training and benchmarking to use the shared helper: `training/train.py` now skips sentences that can’t be reliably marked (instead of producing unmarked examples), and `wsd/benchmark.py` replaces its inline regex/substitution logic with the helper while preserving “skip on miss” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd41f69ba2f7ac38ad590bfc1c90597367f0cd9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->