### PR TITLE
feat(train): add --weight-decay, --label-smoothing, --lr-scheduler CLI knobs

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -34,6 +34,9 @@ DEFAULT_BATCH_SIZE = 64
 DEFAULT_LEARNING_RATE = 3e-5
 DEFAULT_WARMUP_RATIO = 0.1
 DEFAULT_RANDOM_SEED = 42
+DEFAULT_WEIGHT_DECAY = 0.0
+DEFAULT_LABEL_SMOOTHING = 0.0
+DEFAULT_LR_SCHEDULER = "linear"
 NONE_SUFFIX = "_none"
 
 
@@ -51,6 +54,9 @@ class TrainingConfig:
     random_seed: int = DEFAULT_RANDOM_SEED
     report_to: str = "wandb"
     max_steps: int = -1  # -1 means no limit (train full epochs)
+    weight_decay: float = DEFAULT_WEIGHT_DECAY
+    label_smoothing: float = DEFAULT_LABEL_SMOOTHING
+    lr_scheduler: str = DEFAULT_LR_SCHEDULER
 
 
 @dataclass
@@ -459,6 +465,24 @@ def main():
         help="Maximum number of training steps (-1 for no limit, useful for debugging)"
     )
     parser.add_argument("--seed", type=int, default=DEFAULT_RANDOM_SEED, help="Random seed")
+    parser.add_argument(
+        "--weight-decay",
+        type=float,
+        default=DEFAULT_WEIGHT_DECAY,
+        help="AdamW weight decay (L2 regularization)",
+    )
+    parser.add_argument(
+        "--label-smoothing",
+        type=float,
+        default=DEFAULT_LABEL_SMOOTHING,
+        help="Label smoothing factor passed to TrainingArguments.label_smoothing_factor",
+    )
+    parser.add_argument(
+        "--lr-scheduler",
+        type=str,
+        default=DEFAULT_LR_SCHEDULER,
+        help="HuggingFace LR scheduler type (e.g. linear, cosine, cosine_with_restarts)",
+    )
     args = parser.parse_args()
 
     # Create configuration
@@ -471,6 +495,9 @@ def main():
         num_epochs=args.num_epochs,
         max_steps=args.max_steps,
         random_seed=args.seed,
+        weight_decay=args.weight_decay,
+        label_smoothing=args.label_smoothing,
+        lr_scheduler=args.lr_scheduler,
     )
 
     # Set random seeds for reproducibility
@@ -517,6 +544,9 @@ def main():
         per_device_train_batch_size=config.batch_size,
         learning_rate=config.learning_rate,
         warmup_ratio=config.warmup_ratio,
+        weight_decay=config.weight_decay,
+        label_smoothing_factor=config.label_smoothing,
+        lr_scheduler_type=config.lr_scheduler,
         logging_steps=10,
         save_strategy="epoch" if config.max_steps == -1 else "steps",
         save_total_limit=1,


### PR DESCRIPTION
## Summary
- Exposes three TrainingArguments as CLI flags so regularization/schedule can be tuned without editing code:
  - \`--weight-decay\` → \`weight_decay\`
  - \`--label-smoothing\` → \`label_smoothing_factor\`
  - \`--lr-scheduler\` → \`lr_scheduler_type\` (e.g. \`linear\`, \`cosine\`, \`cosine_with_restarts\`)
- Defaults preserve prior behavior (0.0, 0.0, \`linear\`).

## Test plan
- [ ] \`python -m training.train --help\` shows the three new flags.
- [ ] \`python -m training.train --weight-decay 0.01 --label-smoothing 0.1 --lr-scheduler cosine --max-steps 2\` runs a smoke step.
- [ ] Omitting the flags produces identical \`TrainingArguments\` to prior behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive CLI/config wiring that only affects training behavior when the new flags are used; defaults keep existing runs unchanged.
> 
> **Overview**
> Adds three new training hyperparameter knobs to `training/train.py` so regularization and LR scheduling can be tuned from the command line.
> 
> Introduces `--weight-decay`, `--label-smoothing`, and `--lr-scheduler`, threads them through `TrainingConfig`, and passes them into HuggingFace `TrainingArguments` (`weight_decay`, `label_smoothing_factor`, `lr_scheduler_type`) with defaults that preserve prior behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2253943ec9a00ced9010f7e00349268fd0e698d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->