### PR TITLE
feat: pin 'none of the above' to a reserved fixed letter slot

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -26,6 +26,7 @@ from transformers import (
 )
 
 from wsd.prompt import (
+    NOTA_LETTER_INDEX,
     Definition,
     WordNotFoundError,
     create_multiple_choice_prompt,
@@ -208,8 +209,8 @@ def create_none_of_above_example(
 
     random.shuffle(frequent_pos_definitions)
 
-    # The correct answer is "none of the above"
-    none_letter = get_option_letter(len(frequent_pos_definitions))
+    # The correct answer is "none of the above" — always the reserved NOTA letter.
+    none_letter = get_option_letter(NOTA_LETTER_INDEX)
 
     prompt = create_multiple_choice_prompt(
         word=word,

--- a/wsd/prompt.py
+++ b/wsd/prompt.py
@@ -3,6 +3,14 @@ from dataclasses import dataclass
 
 NONE_OF_THE_ABOVE = "none of the above"
 
+# Index of the letter reserved for the "none of the above" (NOTA) slot.
+# Fixed across all prompts so the model sees a single, consistent reject token
+# instead of the NOTA meaning rotating across every letter based on option
+# count. The letter lives at the top of the available range so it does not
+# collide with normal option slots; callers must pass at most this many
+# definitions.
+NOTA_LETTER_INDEX = 108
+
 
 class OptionLetterIndexError(ValueError):
     """Raised when index is too large for option letter"""
@@ -84,17 +92,23 @@ def create_multiple_choice_prompt(word: str,
                                   mask_token: str,
                                   marked_sentence: str,
                                   definitions: list[Definition]) -> str:
-    """Create multiple choice prompt for word sense disambiguation"""
-    if len(definitions) > 100:
-        print(f"Warning: too many definitions ({len(definitions)}) for word '{word}'")
+    """Create multiple choice prompt for word sense disambiguation.
+
+    The letter at :data:`NOTA_LETTER_INDEX` is always reserved for the
+    "none of the above" option, so it is a stable reject signal across all
+    prompts. Definitions occupy letters ``0..NOTA_LETTER_INDEX-1``.
+    """
+    if len(definitions) > NOTA_LETTER_INDEX:
+        raise OptionLetterIndexError(len(definitions))
 
     choices = []
     for i, definition_obj in enumerate(definitions):
         letter = get_option_letter(i)
         choices.append(f"{letter}. {definition_obj.definition}")
 
-    # Add "none of the above" option using next sequential letter
-    none_letter = get_option_letter(len(definitions))
+    # NOTA always uses the reserved letter, regardless of how many
+    # definitions preceded it. Training and inference agree on this index.
+    none_letter = get_option_letter(NOTA_LETTER_INDEX)
     choices.append(f"{none_letter}. {NONE_OF_THE_ABOVE}")
     choices_lines = "\n".join(choices)
     return f"""What is the meaning of *{word}* in this sentence?

--- a/wsd/test_word_sense_disambiguation.py
+++ b/wsd/test_word_sense_disambiguation.py
@@ -3,6 +3,7 @@ import requests_mock
 
 from wsd.env import WORDNET_URL
 from wsd.masked_language_model import load_model
+from wsd.prompt import NOTA_LETTER_INDEX, get_option_letter
 from wsd.word_sense_disambiguation import (
     NO_DEFINITIONS_FOUND,
     NONE_OF_THE_ABOVE,
@@ -172,7 +173,9 @@ def test_create_multiple_choice_prompt():
     assert "bank" in prompt.lower()
     assert "A. a financial institution" in prompt
     assert "B. the edge of a river" in prompt
-    assert f"C. {NONE_OF_THE_ABOVE}" in prompt
+    # NOTA is pinned to the reserved letter, not the next sequential letter.
+    nota_letter = get_option_letter(NOTA_LETTER_INDEX)
+    assert f"{nota_letter}. {NONE_OF_THE_ABOVE}" in prompt
     assert components.tokenizer.mask_token in prompt
 
 

--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -9,6 +9,7 @@ from wsd.env import WORDNET_URL
 from wsd.masked_language_model import load_model, unmask_token, unmask_token_batch
 from wsd.prompt import (
     NONE_OF_THE_ABOVE,
+    NOTA_LETTER_INDEX,
     Definition,
     create_marked_sentence,
     create_multiple_choice_prompt,
@@ -239,8 +240,8 @@ def get_choice_probabilities(tokenizer, probs, definitions: list[Definition]) ->
 
         choice_probs.append(total_prob)
 
-    # Add probability for next letter (none of the above)
-    none_letter = get_option_letter(len(definitions))
+    # NOTA always lives at the reserved letter, independent of len(definitions).
+    none_letter = get_option_letter(NOTA_LETTER_INDEX)
     none_token_id = tokenizer.convert_tokens_to_ids(none_letter)
     space_none_token_id = tokenizer.convert_tokens_to_ids(f" {none_letter}")
 


### PR DESCRIPTION
## Summary
- Reserves a single, fixed letter index (\`NOTA_LETTER_INDEX = 108\`, the top of the currently addressable range) for the \"none of the above\" (NOTA) option in \`wsd/prompt.py\`.
- Previously the NOTA letter rotated with the number of definitions (\`get_option_letter(len(definitions))\`), so its meaning depended on option count. This made the reject signal unstable across prompts and split the NOTA token probability across many letters.
- Training labels (\`training/train.py\`), prompt rendering (\`wsd/prompt.py\`), and inference-time probability lookup (\`wsd/word_sense_disambiguation.py\`) now all agree on the same fixed letter.

## Caveat — retraining required
The published \`sign/ModernBERT-Large-Instruct-WSD\` model was trained with the old position-dependent NOTA; loading it against this code will misattribute its NOTA signal. A follow-up training run is required to realign the model with the new slot.

## Test plan
- [ ] \`pytest wsd/test_word_sense_disambiguation.py -v\` passes.
- [ ] Manually render a prompt with 2 definitions and confirm NOTA letter is the reserved one, not \"C.\".
- [ ] Retrain and benchmark to confirm eval accuracy moves as expected with the consistent reject signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the labeling/prompt contract for NOTA across training and inference; existing models trained with the old rotating NOTA position may produce incorrect results until retrained.
> 
> **Overview**
> Pins the "none of the above" (NOTA) choice to a single reserved option letter via new `NOTA_LETTER_INDEX = 108`, so the reject signal is stable across prompts instead of shifting with the number of definitions.
> 
> Updates prompt generation, training-label creation, and inference-time probability lookup to all use the reserved NOTA letter, and adds a hard guard that raises if too many definitions would collide with the reserved slot. Tests are adjusted to assert the new fixed NOTA letter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02455d1e1213e679624d61c17daadba081bc5062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->