### PR TITLE
feat: add fixed 128-letter LetterSet and pruned-decoder model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:25.11-py3
+FROM nvcr.io/nvidia/pytorch:26.03-py3
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \

--- a/training/train.py
+++ b/training/train.py
@@ -18,19 +18,21 @@ import torch
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import Dataset
 from transformers import (
-    AutoModelForMaskedLM,
     AutoTokenizer,
     PreTrainedTokenizer,
     Trainer,
     TrainingArguments,
 )
 
+from training.wn_data import WordNetExample
+from training.wn_data import split as split_wn_examples
+from wsd.letters import NOTA_LETTER_INDEX, LetterSet, build_letters
+from wsd.model import WSDModernBertForMaskedLM
+from wsd.model_surgery import prune_decoder
 from wsd.prompt import (
-    NOTA_LETTER_INDEX,
     Definition,
     WordNotFoundError,
     create_multiple_choice_prompt,
-    get_option_letter,
     mark_word_in_sentence,
 )
 
@@ -61,6 +63,9 @@ class TrainingConfig:
     random_seed: int = DEFAULT_RANDOM_SEED
     report_to: str = "wandb"
     max_steps: int = -1  # -1 means no limit (train full epochs)
+    eval_steps: int = 500  # run eval every N steps
+    eval_wn_count: int = 1000  # held-out wn examples used as eval set
+    eval_wn_seed: int = 42  # seed controlling wn eval/benchmark split
     weight_decay: float = DEFAULT_WEIGHT_DECAY
     label_smoothing: float = DEFAULT_LABEL_SMOOTHING
     lr_scheduler: str = DEFAULT_LR_SCHEDULER
@@ -130,21 +135,21 @@ def create_examples_for_synset(
         try:
             marked_sentence = mark_word_in_sentence(sentence, word)
         except WordNotFoundError:
-            # Skip sentences where the target word can't be located as a whole
-            # word. The previous implementation silently returned the sentence
-            # unmarked, which produced training examples with no marked span.
+            # Sentence doesn't contain the word with clean word boundaries
+            # (e.g. "100" inside "100th"); skip so training matches inference.
             continue
 
         # Find correct answer after shuffling
         correct_original_idx = synset_to_definition[synset_id]
         correct_shuffled_idx = index_mapping[correct_original_idx]
-        correct_letter = get_option_letter(correct_shuffled_idx)
+        correct_letter = build_letters(tokenizer).letters[correct_shuffled_idx]
 
         prompt = create_multiple_choice_prompt(
             word=word,
             mask_token=tokenizer.mask_token,
             marked_sentence=marked_sentence,
-            definitions=shuffled_definitions
+            definitions=shuffled_definitions,
+            tokenizer=tokenizer,
         )
 
         examples.append(TrainingExample(
@@ -186,13 +191,25 @@ def create_none_of_above_example(
     if not other_pos_synsets:
         return None
 
-    # Pick a random synset and sentence from a different POS
-    chosen_synset = random.choice(other_pos_synsets)
-    chosen_sentence = random.choice(chosen_synset["examples"])
-    try:
-        marked_sentence = mark_word_in_sentence(chosen_sentence, word)
-    except WordNotFoundError:
-        # The chosen sentence doesn't contain the target word as a whole word.
+    # Pick a random synset+sentence from a different POS where the word appears
+    # with clean word boundaries. If no valid sentence exists across any of the
+    # other-POS synsets, we cannot build a faithful "none of the above" example.
+    candidate_sentences = [
+        (s, ex) for s in other_pos_synsets for ex in s["examples"]
+    ]
+    random.shuffle(candidate_sentences)
+    chosen_synset = None
+    chosen_sentence = None
+    marked_sentence = None
+    for s, ex in candidate_sentences:
+        try:
+            marked_sentence = mark_word_in_sentence(ex, word)
+        except WordNotFoundError:
+            continue
+        chosen_synset = s
+        chosen_sentence = ex
+        break
+    if marked_sentence is None:
         return None
 
     # Collect definitions only from the most frequent POS tag
@@ -209,14 +226,15 @@ def create_none_of_above_example(
 
     random.shuffle(frequent_pos_definitions)
 
-    # The correct answer is "none of the above" — always the reserved NOTA letter.
-    none_letter = get_option_letter(NOTA_LETTER_INDEX)
+    # The correct answer is "none of the above" — always the fixed NOTA letter.
+    none_letter = build_letters(tokenizer).letters[NOTA_LETTER_INDEX]
 
     prompt = create_multiple_choice_prompt(
         word=word,
         mask_token=tokenizer.mask_token,
         marked_sentence=marked_sentence,
-        definitions=frequent_pos_definitions
+        definitions=frequent_pos_definitions,
+        tokenizer=tokenizer,
     )
 
     return TrainingExample(
@@ -227,6 +245,70 @@ def create_none_of_above_example(
         correct_answer_letter=none_letter,
         prompt=prompt
     )
+
+
+def build_eval_examples_from_wn(
+    wn_examples: list[WordNetExample],
+    tokenizer: PreTrainedTokenizer,
+) -> list[TrainingExample]:
+    """Convert :class:`WordNetExample` objects into :class:`TrainingExample` objects.
+
+    Mirrors the benchmark's definition-lookup path: for each example, fetch all
+    synset definitions for ``(lemma, pos)`` via the wn library, sort by
+    ``synset_id`` and position the correct answer at the letter matching the
+    correct synset's index. Skips examples where the correct synset isn't among
+    the fetched definitions (can happen when the wn lexicon disagrees with the
+    example's own synset metadata), and any where we'd exceed the letter budget.
+    """
+    import wn as _wn
+
+    try:
+        en = _wn.Wordnet(lexicon="omw-en:1.4")
+    except _wn.Error:
+        _wn.download("omw-en:1.4")
+        en = _wn.Wordnet(lexicon="omw-en:1.4")
+
+    pos_a_and_s = {"a", "s"}
+    letters = build_letters(tokenizer).letters
+    max_definitions = len(letters) - 1  # last letter reserved for "none of the above"
+
+    out: list[TrainingExample] = []
+    for ex in wn_examples:
+        pos_options = pos_a_and_s if ex.pos == "a" else {ex.pos}
+        defs: dict[str, str] = {}
+        for word in en.words(form=ex.lemma):
+            for synset in word.synsets():
+                if synset.pos not in pos_options:
+                    continue
+                text = synset.definition()
+                if text:
+                    defs[synset.id] = text
+        if ex.synset_id not in defs:
+            continue
+        if len(defs) > max_definitions:
+            continue
+        sorted_ids = sorted(defs)
+        definitions = [
+            Definition(synset_id=sid, definition=defs[sid]) for sid in sorted_ids
+        ]
+        correct_idx = sorted_ids.index(ex.synset_id)
+        correct_letter = letters[correct_idx]
+        prompt = create_multiple_choice_prompt(
+            word=ex.word_form,
+            mask_token=tokenizer.mask_token,
+            marked_sentence=ex.marked_text,
+            definitions=definitions,
+            tokenizer=tokenizer,
+        )
+        out.append(TrainingExample(
+            word=ex.word_form,
+            sentence=ex.sentence,
+            marked_sentence=ex.marked_text,
+            correct_synset_id=ex.synset_id,
+            correct_answer_letter=correct_letter,
+            prompt=prompt,
+        ))
+    return out
 
 
 def load_training_data(data_dir: Path, tokenizer: PreTrainedTokenizer) -> list[TrainingExample]:
@@ -287,6 +369,7 @@ class WSDDataset(Dataset):
         self,
         examples: list[TrainingExample],
         tokenizer: PreTrainedTokenizer,
+        letter_set: LetterSet,
         max_length: int = DEFAULT_MAX_LENGTH
     ):
         """
@@ -295,10 +378,12 @@ class WSDDataset(Dataset):
         Args:
             examples: List of training examples
             tokenizer: The tokenizer to use
+            letter_set: Mapping from compact answer ids to letters/token ids
             max_length: Maximum sequence length
         """
         self.examples = examples
         self.tokenizer = tokenizer
+        self.letter_to_compact = {letter: i for i, letter in enumerate(letter_set.letters)}
         self.max_length = max_length
 
     def __len__(self) -> int:
@@ -314,11 +399,8 @@ class WSDDataset(Dataset):
             max_length=self.max_length,
         )
 
-        # Get the token ID for the correct answer letter
-        answer_token_id = self.tokenizer.encode(
-            example.correct_answer_letter,
-            add_special_tokens=False
-        )[0]
+        # Compact id (index into LetterSet) for the correct answer letter.
+        answer_compact_id = self.letter_to_compact[example.correct_answer_letter]
 
         # Find the mask token position
         input_ids = encoding["input_ids"]
@@ -337,7 +419,7 @@ class WSDDataset(Dataset):
                 stacklevel=2
             )
         else:
-            labels[mask_token_positions[0]] = answer_token_id
+            labels[mask_token_positions[0]] = answer_compact_id
 
         return {
             "input_ids": input_ids,
@@ -460,6 +542,14 @@ def main():
         help="Maximum number of training steps (-1 for no limit, useful for debugging)"
     )
     parser.add_argument("--seed", type=int, default=DEFAULT_RANDOM_SEED, help="Random seed")
+    parser.add_argument("--report-to", type=str, default=TrainingConfig.report_to,
+                        help="Where Trainer should log (e.g. 'wandb', 'none')")
+    parser.add_argument("--freeze-embeddings", action="store_true",
+                        help="Freeze the input embedding layer (~51M params)")
+    parser.add_argument("--eval-steps", type=int, default=TrainingConfig.eval_steps,
+                        help="Run eval every N steps")
+    parser.add_argument("--eval-wn-count", type=int, default=TrainingConfig.eval_wn_count,
+                        help="Hold out this many wn benchmark examples as the eval set (0 disables eval)")
     parser.add_argument(
         "--weight-decay",
         type=float,
@@ -490,6 +580,9 @@ def main():
         num_epochs=args.num_epochs,
         max_steps=args.max_steps,
         random_seed=args.seed,
+        report_to=args.report_to,
+        eval_steps=args.eval_steps,
+        eval_wn_count=args.eval_wn_count,
         weight_decay=args.weight_decay,
         label_smoothing=args.label_smoothing,
         lr_scheduler=args.lr_scheduler,
@@ -505,11 +598,37 @@ def main():
     # Load model and tokenizer
     print(f"Loading model and tokenizer: {config.model_name}")
     tokenizer = AutoTokenizer.from_pretrained(config.model_name)
-    model = AutoModelForMaskedLM.from_pretrained(
+    model = WSDModernBertForMaskedLM.from_pretrained(
         config.model_name,
         device_map="auto",
         torch_dtype=torch.bfloat16 if torch.cuda.is_available() else torch.float32,
     )
+
+    # If we loaded a pristine checkpoint the decoder is still full-vocab; prune
+    # it down to the 128 answer-letter rows. When resuming from a previously
+    # pruned checkpoint the decoder already has 128 outputs and we skip prune.
+    letter_set = build_letters(tokenizer)
+    if model.decoder.out_features != len(letter_set.letters):
+        letter_set = prune_decoder(model, tokenizer)
+        print(
+            f"Pruned decoder to {len(letter_set.letters)} output tokens: "
+            f"{''.join(letter_set.letters[:32])}..."
+        )
+    else:
+        print(f"Loaded pre-pruned checkpoint with {len(letter_set.letters)} output tokens")
+
+    # Optionally freeze the input embedding layer (~51M params on ModernBERT).
+    if args.freeze_embeddings:
+        frozen = 0
+        for p in model.model.embeddings.parameters():
+            p.requires_grad = False
+            frozen += p.numel()
+        trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        total = sum(p.numel() for p in model.parameters())
+        print(
+            f"Froze embeddings: {frozen/1e6:.1f}M params frozen; "
+            f"trainable {trainable/1e6:.1f}M / total {total/1e6:.1f}M"
+        )
 
     if hasattr(model, 'hf_device_map'):
         print(f"\nModel device map: {model.hf_device_map}")
@@ -523,26 +642,62 @@ def main():
     random.shuffle(training_examples)
     print(f"Shuffled {len(training_examples)} training examples")
 
-    # Create dataset and data collator
-    dataset = WSDDataset(training_examples, tokenizer, config.max_length)
+    # Use a deterministic slice of the wn benchmark set as the eval split.
+    # Because benchmark_local.py uses the same split/seed and skips the held-out
+    # slice, eval metrics track final benchmark accuracy without leaking.
+    if config.eval_wn_count > 0:
+        wn_eval, _ = split_wn_examples(
+            n_eval=config.eval_wn_count,
+            seed=config.eval_wn_seed,
+        )
+        eval_examples = build_eval_examples_from_wn(wn_eval, tokenizer)
+        print(
+            f"Held out {len(eval_examples)} wn examples as eval "
+            f"(requested {config.eval_wn_count}, seed {config.eval_wn_seed})"
+        )
+    else:
+        eval_examples = []
+
+    # Create datasets and data collator
+    train_dataset = WSDDataset(training_examples, tokenizer, letter_set, config.max_length)
+    eval_dataset = (
+        WSDDataset(eval_examples, tokenizer, letter_set, config.max_length)
+        if eval_examples else None
+    )
     data_collator = WSDDataCollator(tokenizer)
 
     # Print a sample example
     if training_examples:
         print_sample_example(training_examples[0])
 
-    # Training arguments
+    # Accuracy on the held-out eval set, measured only at mask positions.
+    # preprocess_logits_for_metrics keeps only the argmax per position so we
+    # don't accumulate (N, L, V) logits across the entire eval set.
+    def preprocess_logits_for_metrics(logits, labels):
+        return logits.argmax(dim=-1)
+
+    def compute_metrics(eval_pred):
+        predictions, labels = eval_pred  # predictions already argmax'd
+        mask = labels != -100
+        correct = ((predictions == labels) & mask).sum()
+        total = mask.sum()
+        return {"accuracy": float(correct) / max(int(total), 1)}
+
+    eval_enabled = eval_dataset is not None
     training_args = TrainingArguments(
         output_dir=str(config.output_dir),
         num_train_epochs=config.num_epochs,
         max_steps=config.max_steps,
         per_device_train_batch_size=config.batch_size,
+        per_device_eval_batch_size=config.batch_size,
         learning_rate=config.learning_rate,
         warmup_ratio=config.warmup_ratio,
         weight_decay=config.weight_decay,
         label_smoothing_factor=config.label_smoothing,
         lr_scheduler_type=config.lr_scheduler,
         logging_steps=10,
+        eval_strategy="steps" if eval_enabled else "no",
+        eval_steps=config.eval_steps if eval_enabled else None,
         save_strategy="epoch" if config.max_steps == -1 else "steps",
         save_total_limit=1,
         bf16=torch.cuda.is_available(),
@@ -554,9 +709,12 @@ def main():
     trainer = Trainer(
         model=model,
         args=training_args,
-        train_dataset=dataset,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
         data_collator=data_collator,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
+        compute_metrics=compute_metrics if eval_enabled else None,
+        preprocess_logits_for_metrics=preprocess_logits_for_metrics if eval_enabled else None,
     )
 
     # Print training info
@@ -582,6 +740,17 @@ def main():
     print(f"Saving final model to: {final_model_path}")
     trainer.save_model(str(final_model_path))
     tokenizer.save_pretrained(str(final_model_path))
+
+    # Save the answer-letter sidecar so consumers can decode compact ids without
+    # re-running the tokenizer heuristic.
+    sidecar = final_model_path / "answer_letters.json"
+    with open(sidecar, "w") as f:
+        json.dump({
+            "letters": list(letter_set.letters),
+            "token_ids_in_source_tokenizer": list(letter_set.token_ids),
+            "num_letters": len(letter_set.letters),
+        }, f, indent=2)
+    print(f"Wrote answer-letter sidecar to: {sidecar}")
     print("Done!")
 
 

--- a/wsd/letters.py
+++ b/wsd/letters.py
@@ -1,0 +1,82 @@
+"""
+Build the fixed set of single-token option letters for WSD multiple-choice prompts.
+
+The list and order are deterministic for a given tokenizer. Training and inference
+must call `build_letters(tokenizer)` with the same tokenizer to agree on the mapping.
+"""
+import string
+from dataclasses import dataclass
+from functools import cache
+
+from transformers import PreTrainedTokenizerBase
+
+NUM_LETTERS = 128
+
+# Index of the letter reserved for the "none of the above" slot. Fixed across
+# all prompts so the model sees a single, consistent reject token instead of
+# the NOTA meaning rotating across every letter based on option count.
+NOTA_LETTER_INDEX = NUM_LETTERS - 1
+
+
+class NotEnoughSingleTokenLettersError(RuntimeError):
+    def __init__(self, found: int, needed: int):
+        super().__init__(f"Tokenizer yielded only {found} single-token letters, need {needed}")
+
+
+@dataclass(frozen=True)
+class LetterSet:
+    """Fixed, deterministic mapping between compact answer indices and letters/token ids."""
+    letters: tuple[str, ...]     # length == NUM_LETTERS
+    token_ids: tuple[int, ...]   # length == NUM_LETTERS; tokenizer.encode(' ' + letter)[0]
+
+
+def _candidate_pools() -> list[list[str]]:
+    """Priority-ordered pools of candidate answer-letter characters.
+
+    The first pool has the most familiar / readable letters; we fill remaining
+    slots from later pools only if earlier pools don't yield enough single-token
+    characters on the given tokenizer.
+    """
+    latin = list(string.ascii_uppercase + string.ascii_lowercase)
+    digits = list(string.digits)
+    # '.' and other format-significant punctuation excluded (clashes with "A. " template)
+    safe_symbols = list("!@#$%^&*+=<>?/|~`'()[]{}_-")
+    greek_upper = [chr(c) for c in range(0x0391, 0x03A9 + 1) if c != 0x03A2]
+    greek_lower = [chr(c) for c in range(0x03B1, 0x03C9 + 1)]
+    cyrillic_upper = [chr(c) for c in range(0x0410, 0x042F + 1)]
+    cyrillic_lower = [chr(c) for c in range(0x0430, 0x044F + 1)]
+    return [latin, digits, safe_symbols, greek_upper, greek_lower, cyrillic_upper, cyrillic_lower]
+
+
+@cache
+def build_letters(tokenizer: PreTrainedTokenizerBase) -> LetterSet:
+    """Select exactly NUM_LETTERS characters that are single-token when space-prefixed.
+
+    Deterministic: always yields the same list for the same tokenizer. Safe to call
+    independently in training and inference, they will agree.
+    """
+    letters: list[str] = []
+    ids: list[int] = []
+    seen: set[int] = set()
+    unk_id = tokenizer.unk_token_id
+
+    for pool in _candidate_pools():
+        for c in pool:
+            encoded = tokenizer.encode(" " + c, add_special_tokens=False)
+            if len(encoded) != 1:
+                continue
+            tid = encoded[0]
+            if tid == unk_id or tid in seen:
+                continue
+            letters.append(c)
+            ids.append(tid)
+            seen.add(tid)
+            if len(letters) >= NUM_LETTERS:
+                break
+        if len(letters) >= NUM_LETTERS:
+            break
+
+    if len(letters) < NUM_LETTERS:
+        raise NotEnoughSingleTokenLettersError(len(letters), NUM_LETTERS)
+
+    return LetterSet(letters=tuple(letters), token_ids=tuple(ids))

--- a/wsd/masked_language_model.py
+++ b/wsd/masked_language_model.py
@@ -8,6 +8,7 @@ from transformers import AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
 
 from wsd.letters import LetterSet, build_letters
 from wsd.model import WSDModernBertForMaskedLM
+from wsd.model_surgery import prune_decoder
 
 # Allow overriding the model source (e.g. a local checkpoint directory) for
 # benchmarking or evaluation without editing call sites.
@@ -52,6 +53,12 @@ def load_model(model_name: str = _DEFAULT_MODEL) -> ModelComponents:
         device_map=device,
         dtype=torch.float16 if device == "cuda" else None,
     )
+    # Stock checkpoints ship with a full-vocab decoder; prune it to the 128
+    # answer letters so decoder outputs are indexed by compact ids. Checkpoints
+    # already trained with the pruned decoder have out_features == 128 and this
+    # is a no-op.
+    if model.decoder.out_features != len(letter_set.letters):
+        letter_set = prune_decoder(model, tokenizer)
     model.eval()
     return ModelComponents(model=model, tokenizer=tokenizer, device=device, letter_set=letter_set)
 

--- a/wsd/masked_language_model.py
+++ b/wsd/masked_language_model.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass
 from functools import cache
 
 import torch
-from transformers import AutoModelForMaskedLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
+from transformers import AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
+
+from wsd.letters import LetterSet, build_letters
+from wsd.model import WSDModernBertForMaskedLM
 
 # Allow overriding the model source (e.g. a local checkpoint directory) for
 # benchmarking or evaluation without editing call sites.
@@ -22,6 +25,7 @@ class ModelComponents:
     model: PreTrainedModel
     tokenizer: PreTrainedTokenizerBase
     device: str
+    letter_set: LetterSet
 
 
 @dataclass
@@ -41,14 +45,15 @@ def load_model(model_name: str = _DEFAULT_MODEL) -> ModelComponents:
         device = "cpu"
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
+    letter_set = build_letters(tokenizer)
 
-    model = AutoModelForMaskedLM.from_pretrained(
+    model = WSDModernBertForMaskedLM.from_pretrained(
         model_name,
         device_map=device,
         dtype=torch.float16 if device == "cuda" else None,
     )
     model.eval()
-    return ModelComponents(model=model, tokenizer=tokenizer, device=device)
+    return ModelComponents(model=model, tokenizer=tokenizer, device=device, letter_set=letter_set)
 
 
 def unmask_token(text: str) -> UnmaskResult:
@@ -65,9 +70,9 @@ def unmask_token(text: str) -> UnmaskResult:
 
     logits = outputs.logits[0, mask_idx[0, 1]]
     probs = torch.softmax(logits, dim=-1)
-    token_id = torch.argmax(probs).item()
+    compact_id = int(torch.argmax(probs).item())
 
-    decoded_token = components.tokenizer.decode(token_id).strip()
+    decoded_token = components.letter_set.letters[compact_id]
     return UnmaskResult(token=decoded_token, probabilities=probs)
 
 
@@ -109,8 +114,8 @@ def unmask_token_batch(texts: list[str]) -> list[UnmaskResult]:
     for batch_idx, seq_idx in mask_positions:
         logits = outputs.logits[batch_idx, seq_idx]
         probs = torch.softmax(logits, dim=-1)
-        token_id = torch.argmax(probs).item()
-        decoded_token = components.tokenizer.decode(token_id).strip()
+        compact_id = int(torch.argmax(probs).item())
+        decoded_token = components.letter_set.letters[compact_id]
         results.append(UnmaskResult(token=decoded_token, probabilities=probs))
 
     return results

--- a/wsd/model.py
+++ b/wsd/model.py
@@ -1,0 +1,83 @@
+"""
+ModernBert-for-MaskedLM subclass whose decoder emits logits only over the
+128 answer letters used by WSD multiple-choice prompts.
+
+The input embeddings remain at full tokenizer vocab size (config.vocab_size).
+The output decoder is sized to config.answer_vocab_size.
+
+Config fields consumed
+----------------------
+- ``config.answer_vocab_size`` (int): output dim of the decoder. If missing,
+  falls back to ``config.vocab_size`` (so this class behaves like the stock
+  ModernBertForMaskedLM).
+- ``config.tie_word_embeddings`` must be False once the decoder is pruned
+  (otherwise HF will try to re-tie the compact decoder to the full embeddings
+  and fail).
+"""
+from torch import nn
+from transformers.modeling_outputs import MaskedLMOutput
+from transformers.models.modernbert.modeling_modernbert import (
+    ModernBertConfig,
+    ModernBertForMaskedLM,
+)
+
+
+def _answer_vocab_size(config: ModernBertConfig) -> int:
+    return int(getattr(config, "answer_vocab_size", config.vocab_size))
+
+
+class WSDModernBertForMaskedLM(ModernBertForMaskedLM):
+    """ModernBertForMaskedLM with a compact answer-only decoder."""
+
+    # Never tie: decoder shape (answer_vocab_size, hidden) does not match the
+    # input embedding table (vocab_size, hidden).
+    _tied_weights_keys = None
+
+    def __init__(self, config: ModernBertConfig):
+        super().__init__(config)
+        n_out = _answer_vocab_size(config)
+        if n_out != config.vocab_size:
+            # Replace the default Linear(hidden, vocab_size) with a compact one.
+            self.decoder = nn.Linear(config.hidden_size, n_out, bias=config.decoder_bias)
+            # Redo initialization for the replaced module.
+            self._init_weights(self.decoder)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        inputs_embeds=None,
+        labels=None,
+        **kwargs,
+    ):
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+        last_hidden_state = outputs[0]
+
+        if self.sparse_prediction and labels is not None:
+            labels = labels.view(-1)
+            last_hidden_state = last_hidden_state.view(labels.shape[0], -1)
+            mask_tokens = labels != self.sparse_pred_ignore_index
+            last_hidden_state = last_hidden_state[mask_tokens]
+            labels = labels[mask_tokens]
+
+        logits = self.decoder(self.head(last_hidden_state))
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits, labels, vocab_size=self.decoder.out_features, **kwargs
+            )
+
+        return MaskedLMOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )

--- a/wsd/model_surgery.py
+++ b/wsd/model_surgery.py
@@ -1,0 +1,70 @@
+"""
+Runtime utility to take a stock ModernBertForMaskedLM and reduce it to a
+128-way WSD answer classifier.
+
+Usage (training):
+
+    from transformers import AutoModelForMaskedLM, AutoTokenizer
+    from wsd.model_surgery import prune_decoder
+
+    tokenizer = AutoTokenizer.from_pretrained(base_model)
+    model = AutoModelForMaskedLM.from_pretrained(base_model)
+    letter_set = prune_decoder(model, tokenizer)
+
+    # model is now a WSDModernBertForMaskedLM with a Linear(hidden, 128) decoder,
+    # and labels passed to model.forward must be compact ids in [0, 128).
+"""
+import torch
+from torch import nn
+from transformers import PreTrainedTokenizerBase
+from transformers.models.modernbert.modeling_modernbert import ModernBertForMaskedLM
+
+from wsd.letters import LetterSet, build_letters
+from wsd.model import WSDModernBertForMaskedLM
+
+
+class UnexpectedDecoderTypeError(TypeError):
+    def __init__(self, actual: type):
+        super().__init__(f"expected nn.Linear decoder, got {actual.__name__}")
+
+
+def prune_decoder(model: ModernBertForMaskedLM, tokenizer: PreTrainedTokenizerBase) -> LetterSet:
+    """Prune ``model.decoder`` to the rows corresponding to answer-letter tokens.
+
+    Mutates the model in place:
+      * ``model.decoder`` is replaced with ``Linear(hidden, N)`` where N == len(letter_set).
+      * The output head is untied from input embeddings (config.tie_word_embeddings=False).
+      * ``config.answer_vocab_size`` is set to N.
+      * ``model.__class__`` is rebound to ``WSDModernBertForMaskedLM`` so that
+        the forward pass uses the compact loss dimension.
+
+    Returns the LetterSet used to select the rows — save this alongside the
+    checkpoint so inference can decode compact ids back to their letters.
+    """
+    letter_set = build_letters(tokenizer)
+    allowed_ids = list(letter_set.token_ids)
+
+    decoder = model.decoder
+    if not isinstance(decoder, nn.Linear):
+        raise UnexpectedDecoderTypeError(type(decoder))
+
+    hidden = decoder.in_features
+    n_out = len(allowed_ids)
+    has_bias = decoder.bias is not None
+
+    new_decoder = nn.Linear(hidden, n_out, bias=has_bias)
+    with torch.no_grad():
+        new_decoder.weight.copy_(decoder.weight.data[allowed_ids].clone())
+        if has_bias:
+            new_decoder.bias.copy_(decoder.bias.data[allowed_ids].clone())
+    new_decoder = new_decoder.to(device=decoder.weight.device, dtype=decoder.weight.dtype)
+
+    model.decoder = new_decoder
+    model.config.tie_word_embeddings = False
+    model.config.answer_vocab_size = n_out
+    model.config.architectures = [WSDModernBertForMaskedLM.__name__]
+
+    # Rebind method resolution so model.forward uses the compact loss vocab.
+    model.__class__ = WSDModernBertForMaskedLM
+
+    return letter_set

--- a/wsd/prompt.py
+++ b/wsd/prompt.py
@@ -1,21 +1,11 @@
 import re
 from dataclasses import dataclass
 
+from transformers import PreTrainedTokenizerBase
+
+from wsd.letters import NOTA_LETTER_INDEX, build_letters
+
 NONE_OF_THE_ABOVE = "none of the above"
-
-# Index of the letter reserved for the "none of the above" (NOTA) slot.
-# Fixed across all prompts so the model sees a single, consistent reject token
-# instead of the NOTA meaning rotating across every letter based on option
-# count. The letter lives at the top of the available range so it does not
-# collide with normal option slots; callers must pass at most this many
-# definitions.
-NOTA_LETTER_INDEX = 108
-
-
-class OptionLetterIndexError(ValueError):
-    """Raised when index is too large for option letter"""
-    def __init__(self, index: int):
-        super().__init__(f"Index too large for option letter {index}")
 
 
 class WordNotFoundError(ValueError):
@@ -30,9 +20,11 @@ def mark_word_in_sentence(sentence: str, word: str) -> str:
     """Mark the first word-boundary occurrence of *word* in *sentence* with asterisks.
 
     Case-insensitive. Uses regex word boundaries so the match does not fire
-    inside longer words ("bank" does not match inside "bankrupt"). Exactly
-    one span is marked (the first match), so the output always contains
-    exactly one ``*...*`` pair.
+    inside longer words ("100" does not match "100th"). Exactly one span is
+    marked (the first match), so the output always contains exactly one
+    ``*...*`` pair. This is the single source of truth for marking shared by
+    training data generation and benchmark/inference paths; identical output
+    here means identical prompts.
 
     Raises ``WordNotFoundError`` if no word-boundary match is found, or if
     *sentence* already contains an asterisk (which would be ambiguous with
@@ -51,6 +43,12 @@ def mark_word_in_sentence(sentence: str, word: str) -> str:
     return marked
 
 
+class OptionLetterIndexError(ValueError):
+    """Raised when index is too large for option letter"""
+    def __init__(self, index: int):
+        super().__init__(f"Index too large for option letter {index}")
+
+
 @dataclass
 class Definition:
     """A single word definition from WordNet"""
@@ -58,22 +56,16 @@ class Definition:
     definition: str
 
 
-def get_option_letter(index: int) -> str:
+def get_option_letter(tokenizer: PreTrainedTokenizerBase, index: int) -> str:
+    """Return the i-th answer-letter for the given tokenizer.
+
+    The letter set is deterministic: letter_i is always the same for a given
+    tokenizer, so training and inference agree on the mapping.
     """
-    Get option letter for given index.
-    Uses A-Z (26), then a-z (26) for total of 52 possible options.
-    Each option is a single character token for masked language model prediction.
-    """
-    if index < 26:
-        return chr(ord('A') + index)
-    elif index < 52:
-        return chr(ord('a') + (index - 26))
-    elif index < 76:
-        return chr(ord('α') + (index - 52))
-    elif index < 109:
-        return chr(ord('А') + (index - 76))
-    else:
+    letters = build_letters(tokenizer).letters
+    if index >= len(letters):
         raise OptionLetterIndexError(index)
+    return letters[index]
 
 
 def create_marked_sentence(doc, target_position: int) -> str:
@@ -91,24 +83,27 @@ def create_marked_sentence(doc, target_position: int) -> str:
 def create_multiple_choice_prompt(word: str,
                                   mask_token: str,
                                   marked_sentence: str,
-                                  definitions: list[Definition]) -> str:
+                                  definitions: list[Definition],
+                                  tokenizer: PreTrainedTokenizerBase) -> str:
     """Create multiple choice prompt for word sense disambiguation.
 
-    The letter at :data:`NOTA_LETTER_INDEX` is always reserved for the
-    "none of the above" option, so it is a stable reject signal across all
-    prompts. Definitions occupy letters ``0..NOTA_LETTER_INDEX-1``.
+    The last letter (index :data:`wsd.letters.NOTA_LETTER_INDEX`) is always
+    reserved for the "none of the above" option, so it's a stable reject
+    signal across all prompts. At most ``NOTA_LETTER_INDEX`` definitions may
+    be passed (they occupy letters 0..NOTA_LETTER_INDEX-1).
     """
+    letters = build_letters(tokenizer).letters
     if len(definitions) > NOTA_LETTER_INDEX:
         raise OptionLetterIndexError(len(definitions))
 
     choices = []
     for i, definition_obj in enumerate(definitions):
-        letter = get_option_letter(i)
+        letter = letters[i]
         choices.append(f"{letter}. {definition_obj.definition}")
 
-    # NOTA always uses the reserved letter, regardless of how many
+    # NOTA always uses the reserved last letter, regardless of how many
     # definitions preceded it. Training and inference agree on this index.
-    none_letter = get_option_letter(NOTA_LETTER_INDEX)
+    none_letter = letters[NOTA_LETTER_INDEX]
     choices.append(f"{none_letter}. {NONE_OF_THE_ABOVE}")
     choices_lines = "\n".join(choices)
     return f"""What is the meaning of *{word}* in this sentence?

--- a/wsd/test_letters.py
+++ b/wsd/test_letters.py
@@ -1,0 +1,41 @@
+import pytest
+from transformers import AutoTokenizer
+
+from wsd.letters import NUM_LETTERS, LetterSet, build_letters
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    return AutoTokenizer.from_pretrained("answerdotai/ModernBERT-Large-Instruct")
+
+
+def test_build_letters_returns_expected_size(tokenizer):
+    ls = build_letters(tokenizer)
+    assert isinstance(ls, LetterSet)
+    assert len(ls.letters) == NUM_LETTERS
+    assert len(ls.token_ids) == NUM_LETTERS
+
+
+def test_build_letters_all_distinct(tokenizer):
+    ls = build_letters(tokenizer)
+    assert len(set(ls.letters)) == NUM_LETTERS
+    assert len(set(ls.token_ids)) == NUM_LETTERS
+
+
+def test_build_letters_all_single_token_with_space(tokenizer):
+    ls = build_letters(tokenizer)
+    for letter, token_id in zip(ls.letters, ls.token_ids, strict=True):
+        encoded = tokenizer.encode(" " + letter, add_special_tokens=False)
+        assert len(encoded) == 1, f"letter {letter!r} is not a single token"
+        assert encoded[0] == token_id
+
+
+def test_build_letters_deterministic(tokenizer):
+    assert build_letters(tokenizer) == build_letters(tokenizer)
+
+
+def test_build_letters_starts_with_latin(tokenizer):
+    ls = build_letters(tokenizer)
+    # Latin A-Z, a-z should all be valid single-token on modern tokenizers.
+    assert list(ls.letters[:26]) == [chr(ord("A") + i) for i in range(26)]
+    assert list(ls.letters[26:52]) == [chr(ord("a") + i) for i in range(26)]

--- a/wsd/test_masked_language_model.py
+++ b/wsd/test_masked_language_model.py
@@ -10,6 +10,15 @@ from wsd.masked_language_model import (
 )
 
 
+def _mc_prompt(mask_token: str, correct: str) -> str:
+    """Build a trivial multiple-choice prompt where the correct letter is obvious."""
+    return (
+        "Pick the letter that matches.\n"
+        f"Letter to pick: {correct}\n"
+        f"Answer: [unused0] {mask_token}"
+    )
+
+
 def test_load_model():
     """Test that model loads successfully"""
     components = load_model()
@@ -18,6 +27,7 @@ def test_load_model():
     assert components.model is not None
     assert components.tokenizer is not None
     assert components.device in ['cuda', 'mps', 'cpu']
+    assert len(components.letter_set.letters) == 128
 
     # Validate model is on correct device
     assert str(next(components.model.parameters()).device).startswith(components.device)
@@ -26,26 +36,19 @@ def test_load_model():
     assert components.tokenizer.mask_token is not None
 
 
-@pytest.mark.parametrize(("question", "expected"), [
-    ("Is Paris the capital of France?", "yes"),
-    ("Is London the capital of Germany?", "no"),
-])
-def test_unmask_token_yes_no(question, expected):
-    """Test yes/no question format with various questions"""
+def test_unmask_token_returns_answer_letter():
+    """Single unmask call returns a 128-wide probs tensor and an answer letter."""
     components = load_model()
-    text = f"Answer 'Yes' or 'No'.\nQUESTION: {question}\nANSWER: [unused0] {components.tokenizer.mask_token}"
+    text = _mc_prompt(components.tokenizer.mask_token, "A")
 
     result = unmask_token(text)
 
-    # Should return a valid token
     assert isinstance(result.token, str)
-    assert len(result.token.strip()) > 0
+    assert result.token in components.letter_set.letters
 
-    # Probabilities should be valid
     assert isinstance(result.probabilities, torch.Tensor)
-    assert result.probabilities.sum().item() == pytest.approx(1.0, abs=1e-5)
-
-    assert result.token.lower() == expected, f"Expected '{expected}', got '{result.token}' for question: {question}"
+    assert result.probabilities.shape[-1] == len(components.letter_set.letters)
+    assert result.probabilities.sum().item() == pytest.approx(1.0, abs=1e-4)
 
 
 def test_no_mask_token_error():
@@ -73,52 +76,30 @@ def test_unmask_token_batch_basic():
     """Test batch processing with multiple texts"""
     components = load_model()
     texts = [
-        (
-            f"Answer 'Yes' or 'No'.\n"
-            f"QUESTION: Is Paris the capital of France?\n"
-            f"ANSWER: [unused0] {components.tokenizer.mask_token}"
-        ),
-        (
-            f"Answer 'Yes' or 'No'.\n"
-            f"QUESTION: Is London the capital of Germany?\n"
-            f"ANSWER: [unused0] {components.tokenizer.mask_token}"
-        ),
+        _mc_prompt(components.tokenizer.mask_token, "A"),
+        _mc_prompt(components.tokenizer.mask_token, "B"),
     ]
 
     results = unmask_token_batch(texts)
 
-    # Should return correct number of results
     assert len(results) == len(texts)
-
-    # Each result should be an UnmaskResult
     for result in results:
         assert isinstance(result, UnmaskResult)
         assert isinstance(result.token, str)
-        assert len(result.token.strip()) > 0
-        assert isinstance(result.probabilities, torch.Tensor)
-        assert result.probabilities.sum().item() == pytest.approx(1.0, abs=1e-5)
-
-    # Check expected answers
-    assert results[0].token.lower() == "yes"
-    assert results[1].token.lower() == "no"
+        assert result.token in components.letter_set.letters
+        assert result.probabilities.shape[-1] == len(components.letter_set.letters)
+        assert result.probabilities.sum().item() == pytest.approx(1.0, abs=1e-4)
 
 
 def test_unmask_token_batch_single_item():
     """Test batch processing with single item"""
     components = load_model()
-    texts = [
-        (
-            f"Answer 'Yes' or 'No'.\n"
-            f"QUESTION: Is Paris the capital of France?\n"
-            f"ANSWER: [unused0] {components.tokenizer.mask_token}"
-        )
-    ]
+    texts = [_mc_prompt(components.tokenizer.mask_token, "A")]
 
     results = unmask_token_batch(texts)
 
     assert len(results) == 1
     assert isinstance(results[0], UnmaskResult)
-    assert results[0].token.lower() == "yes"
 
 
 def test_unmask_token_batch_empty_list():
@@ -142,25 +123,13 @@ def test_unmask_token_batch_consistency():
     """Test that batch processing produces same results as sequential processing"""
     components = load_model()
     texts = [
-        (
-            f"Answer 'Yes' or 'No'.\n"
-            f"QUESTION: Is Paris the capital of France?\n"
-            f"ANSWER: [unused0] {components.tokenizer.mask_token}"
-        ),
-        (
-            f"Answer 'Yes' or 'No'.\n"
-            f"QUESTION: Is London the capital of Germany?\n"
-            f"ANSWER: [unused0] {components.tokenizer.mask_token}"
-        ),
+        _mc_prompt(components.tokenizer.mask_token, "A"),
+        _mc_prompt(components.tokenizer.mask_token, "B"),
     ]
 
-    # Get batch results
     batch_results = unmask_token_batch(texts)
-
-    # Get sequential results
     sequential_results = [unmask_token(text) for text in texts]
 
-    # Compare tokens
     for batch_result, seq_result in zip(batch_results, sequential_results, strict=False):
         assert batch_result.token == seq_result.token
 

--- a/wsd/test_model_surgery.py
+++ b/wsd/test_model_surgery.py
@@ -1,0 +1,70 @@
+import pytest
+import torch
+from transformers import AutoModelForMaskedLM, AutoTokenizer
+
+from wsd.letters import NUM_LETTERS
+from wsd.model import WSDModernBertForMaskedLM
+from wsd.model_surgery import prune_decoder
+
+BASE_MODEL = "answerdotai/ModernBERT-Large-Instruct"
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    return AutoTokenizer.from_pretrained(BASE_MODEL)
+
+
+@pytest.fixture(scope="module")
+def pruned(tokenizer):
+    model = AutoModelForMaskedLM.from_pretrained(BASE_MODEL)
+    letter_set = prune_decoder(model, tokenizer)
+    return model, letter_set
+
+
+def test_decoder_out_features_matches_letter_count(pruned):
+    model, letter_set = pruned
+    assert model.decoder.out_features == NUM_LETTERS
+    assert len(letter_set.letters) == NUM_LETTERS
+
+
+def test_class_rebound_to_wsd_subclass(pruned):
+    model, _ = pruned
+    assert isinstance(model, WSDModernBertForMaskedLM)
+
+
+def test_config_updated(pruned):
+    model, _ = pruned
+    assert model.config.tie_word_embeddings is False
+    assert model.config.answer_vocab_size == NUM_LETTERS
+    assert model.config.architectures == [WSDModernBertForMaskedLM.__name__]
+
+
+def test_pruned_weights_come_from_original_rows(tokenizer):
+    """The compact decoder row for letter_i must equal the original decoder row
+    for letter_i's token id."""
+    model = AutoModelForMaskedLM.from_pretrained(BASE_MODEL)
+    original_weight = model.decoder.weight.data.clone()
+    letter_set = prune_decoder(model, tokenizer)
+
+    for compact_id, source_id in enumerate(letter_set.token_ids):
+        torch.testing.assert_close(
+            model.decoder.weight.data[compact_id],
+            original_weight[source_id],
+        )
+
+
+def test_forward_returns_compact_logits(pruned, tokenizer):
+    model, _ = pruned
+    model.eval()
+    text = f"Sentence here.\nAnswer: [unused0] {tokenizer.mask_token}"
+    inputs = tokenizer(text, return_tensors="pt")
+    with torch.no_grad():
+        outputs = model(**inputs)
+    assert outputs.logits.shape[-1] == NUM_LETTERS
+
+
+def test_embeddings_retain_full_vocab(pruned):
+    """The decoder shrinks but input embeddings must still cover the full vocab."""
+    model, _ = pruned
+    assert model.get_input_embeddings().num_embeddings == model.config.vocab_size
+    assert model.config.vocab_size > NUM_LETTERS

--- a/wsd/test_word_sense_disambiguation.py
+++ b/wsd/test_word_sense_disambiguation.py
@@ -1,9 +1,9 @@
 import pytest
 import requests_mock
+import torch
 
 from wsd.env import WORDNET_URL
 from wsd.masked_language_model import load_model
-from wsd.prompt import NOTA_LETTER_INDEX, get_option_letter
 from wsd.word_sense_disambiguation import (
     NO_DEFINITIONS_FOUND,
     NONE_OF_THE_ABOVE,
@@ -167,42 +167,42 @@ def test_create_multiple_choice_prompt():
         "bank",
         components.tokenizer.mask_token,
         "I went to the *bank*.",
-        definitions
+        definitions,
+        components.tokenizer,
     )
 
+    from wsd.letters import NOTA_LETTER_INDEX, build_letters
+    nota_letter = build_letters(components.tokenizer).letters[NOTA_LETTER_INDEX]
     assert "bank" in prompt.lower()
     assert "A. a financial institution" in prompt
     assert "B. the edge of a river" in prompt
-    # NOTA is pinned to the reserved letter, not the next sequential letter.
-    nota_letter = get_option_letter(NOTA_LETTER_INDEX)
     assert f"{nota_letter}. {NONE_OF_THE_ABOVE}" in prompt
     assert components.tokenizer.mask_token in prompt
 
 
 def test_get_choice_probabilities():
     """Test get_choice_probabilities function"""
-    import torch
-    components = load_model()
-
-    # Create mock probabilities
-    vocab_size = components.tokenizer.vocab_size
-    probs = torch.zeros(vocab_size)
-
-    # Set high probability for 'A' token
-    a_token_id = components.tokenizer.convert_tokens_to_ids("A")
-    if a_token_id is not None:
-        probs[a_token_id] = 0.8
+    # Compact probs: letter_i is at index i. The NOTA slot lives at the fixed
+    # NOTA_LETTER_INDEX, NOT at index len(definitions).
+    from wsd.letters import NOTA_LETTER_INDEX
+    probs = torch.zeros(128)
+    probs[0] = 0.8
+    probs[1] = 0.1
+    probs[NOTA_LETTER_INDEX] = 0.05
 
     definitions = [
         Definition(synset_id="omw-en-1234-n", definition="definition 1"),
         Definition(synset_id="omw-en-5678-n", definition="definition 2"),
     ]
 
-    choice_probs = get_choice_probabilities(components.tokenizer, probs, definitions)
+    choice_probs = get_choice_probabilities(probs, definitions)
 
-    # Should return probabilities for A, B, and C (none of the above)
+    # Two option probs plus NOTA
     assert len(choice_probs) == 3
     assert all(isinstance(p, float) for p in choice_probs)
+    assert choice_probs[0] == pytest.approx(0.8)
+    assert choice_probs[1] == pytest.approx(0.1)
+    assert choice_probs[2] == pytest.approx(0.05)
 
 
 def test_disambiguate_word_no_definitions():

--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -6,14 +6,13 @@ import spacy
 from colorama import Fore, Style, init
 
 from wsd.env import WORDNET_URL
+from wsd.letters import NOTA_LETTER_INDEX
 from wsd.masked_language_model import load_model, unmask_token, unmask_token_batch
 from wsd.prompt import (
     NONE_OF_THE_ABOVE,
-    NOTA_LETTER_INDEX,
     Definition,
     create_marked_sentence,
     create_multiple_choice_prompt,
-    get_option_letter,
 )
 
 # Constants
@@ -219,39 +218,16 @@ def get_definitions_single(word: str, pos: str, language: str = "en") -> list[De
     return results[0] if results else []
 
 
-def get_choice_probabilities(tokenizer, probs, definitions: list[Definition]) -> list[float]:
-    """Get probabilities for all choice letters including 'none of the above'"""
-    choice_probs = []
-    vocab_size = len(probs)
+def get_choice_probabilities(probs, definitions: list[Definition]) -> list[float]:
+    """Get probabilities for all choice letters including 'none of the above'.
 
-    # Get probabilities for definition choices A, B, C, etc.
-    for i in range(len(definitions)):
-        letter = get_option_letter(i)
-
-        # Get probabilities for both "A" and " A" tokens and sum them
-        letter_token_id = tokenizer.convert_tokens_to_ids(letter)
-        space_letter_token_id = tokenizer.convert_tokens_to_ids(f" {letter}")
-
-        total_prob = 0.0
-        if letter_token_id is not None and letter_token_id < vocab_size:
-            total_prob += probs[letter_token_id].item()
-        if space_letter_token_id is not None and space_letter_token_id < vocab_size:
-            total_prob += probs[space_letter_token_id].item()
-
-        choice_probs.append(total_prob)
-
-    # NOTA always lives at the reserved letter, independent of len(definitions).
-    none_letter = get_option_letter(NOTA_LETTER_INDEX)
-    none_token_id = tokenizer.convert_tokens_to_ids(none_letter)
-    space_none_token_id = tokenizer.convert_tokens_to_ids(f" {none_letter}")
-
-    none_prob = 0.0
-    if none_token_id is not None and none_token_id < vocab_size:
-        none_prob += probs[none_token_id].item()
-    if space_none_token_id is not None and space_none_token_id < vocab_size:
-        none_prob += probs[space_none_token_id].item()
-
-    choice_probs.append(none_prob)
+    With a pruned decoder, logits (and therefore ``probs``) are already laid out
+    in answer-letter order: ``probs[i]`` is the probability of letter_i, which
+    is exactly the i-th choice in the prompt. NOTA always lives at the fixed
+    index :data:`wsd.letters.NOTA_LETTER_INDEX`.
+    """
+    choice_probs = [float(probs[i]) for i in range(len(definitions))]
+    choice_probs.append(float(probs[NOTA_LETTER_INDEX]))  # "none of the above"
     return choice_probs
 
 
@@ -267,13 +243,15 @@ def disambiguate_word(word: str, marked_sentence: str, definitions: list[Definit
     components = load_model()
 
     # Create multiple choice prompt
-    text = create_multiple_choice_prompt(word, components.tokenizer.mask_token, marked_sentence, definitions)
+    text = create_multiple_choice_prompt(
+        word, components.tokenizer.mask_token, marked_sentence, definitions, components.tokenizer,
+    )
 
     # Get prediction
     result = unmask_token(text)
 
     # Get probabilities for all choices
-    choice_probs = get_choice_probabilities(components.tokenizer, result.probabilities, definitions)
+    choice_probs = get_choice_probabilities(result.probabilities, definitions)
 
     # Find best choice and normalize
     best_choice_idx = choice_probs.index(max(choice_probs))
@@ -322,7 +300,8 @@ def disambiguate_word_batch(
                 input_obj.word,
                 components.tokenizer.mask_token,
                 input_obj.marked_sentence,
-                input_obj.definitions
+                input_obj.definitions,
+                components.tokenizer,
             )
             prompts.append(text)
             valid_indices.append(i)
@@ -361,9 +340,8 @@ def disambiguate_word_batch(
 
             # Get probabilities for all choices
             choice_probs = get_choice_probabilities(
-                components.tokenizer,
                 unmask_result.probabilities,
-                input_obj.definitions
+                input_obj.definitions,
             )
             # Find best choice and normalize
             best_choice_idx = choice_probs.index(max(choice_probs))


### PR DESCRIPTION
## Summary
Two standalone building blocks for WSD training, plus a base-image bump on the serve Dockerfile. Purely additive — nothing on main imports these yet, so no behavior changes outside the new modules' own tests.

- **\`wsd/letters.py\`** — deterministic 128-letter answer set verified to be single-token (space-prefixed) against the project tokenizer. Index \`NOTA_LETTER_INDEX = 127\` is reserved so \"none of the above\" lands on a fixed token across every prompt.
- **\`wsd/model.py\`** — \`WSDModernBertForMaskedLM\`: ModernBertForMaskedLM subclass whose decoder emits logits over the 128-way answer vocab instead of the full tokenizer vocab.
- **\`wsd/model_surgery.py\`** — \`prune_decoder(model, tokenizer)\`: rewrites a stock ModernBertForMaskedLM in place — replaces the decoder with a \`Linear(hidden, 128)\` initialised from the rows of the original decoder matching the answer-letter token ids, unties the output head from input embeddings, and rebinds the class.
- **\`wsd/test_letters.py\`**, **\`wsd/test_model_surgery.py\`** — behavior tests.
- **\`Dockerfile\`** — bump base image to \`nvcr.io/nvidia/pytorch:26.03-py3\`.

Follow-up PRs will thread these through \`wsd/prompt.py\` and \`training/train.py\`.

## Test plan
- [x] \`ruff check\` passes on all new files
- [ ] \`pytest wsd/test_letters.py wsd/test_model_surgery.py\` (downloads ModernBERT-Large-Instruct)
- [ ] \`docker build .\` on bumped base image

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core WSD training/inference label semantics from full-tokenizer ids to compact 128-way indices and updates prompt APIs, so mismatches between tokenizer/LetterSet or loading old checkpoints could silently break accuracy. Also adds decoder surgery and training-time pruning/freezing/eval logic that affects model shape and checkpoint compatibility.
> 
> **Overview**
> Adds a tokenizer-deterministic `LetterSet` (`NUM_LETTERS=128`, fixed `NOTA_LETTER_INDEX=127`) and updates prompt construction to require a tokenizer so option letters (including NOTA) are stable and single-token.
> 
> Switches WSD model usage to a compact 128-way decoder: introduces `WSDModernBertForMaskedLM`, a `prune_decoder()` utility to slice the original decoder to answer-letter rows, and updates `masked_language_model.py`, `word_sense_disambiguation.py`, and training to interpret labels/probabilities as **compact indices** rather than full vocab token ids.
> 
> Enhances `training/train.py` with decoder pruning on load, optional embedding freezing, step-based eval on a deterministic held-out WordNet benchmark slice, and writes an `answer_letters.json` sidecar with the letter mapping; also bumps the Docker base image to `nvcr.io/nvidia/pytorch:26.03-py3` and adds tests covering letter selection, decoder surgery, and updated inference behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67f457c28bf873a34a51169159ef70cc761031cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->