### PR TITLE
refactor: preserve API definition order; dedupe NOTA handling

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -254,11 +254,13 @@ def build_eval_examples_from_wn(
     """Convert :class:`WordNetExample` objects into :class:`TrainingExample` objects.
 
     Mirrors the benchmark's definition-lookup path: for each example, fetch all
-    synset definitions for ``(lemma, pos)`` via the wn library, sort by
-    ``synset_id`` and position the correct answer at the letter matching the
-    correct synset's index. Skips examples where the correct synset isn't among
-    the fetched definitions (can happen when the wn lexicon disagrees with the
-    example's own synset metadata), and any where we'd exceed the letter budget.
+    synset definitions for ``(lemma, pos)`` via the wn library and position the
+    correct answer at the letter matching its index. Definitions are kept in
+    wn iteration order (roughly frequency order) so the more common sense
+    lands on earlier letter slots, matching the inference-time API order.
+    Skips examples where the correct synset isn't among the fetched definitions
+    (can happen when the wn lexicon disagrees with the example's own synset
+    metadata), and any where we'd exceed the letter budget.
     """
     import wn as _wn
 
@@ -287,11 +289,12 @@ def build_eval_examples_from_wn(
             continue
         if len(defs) > max_definitions:
             continue
-        sorted_ids = sorted(defs)
         definitions = [
-            Definition(synset_id=sid, definition=defs[sid]) for sid in sorted_ids
+            Definition(synset_id=sid, definition=text) for sid, text in defs.items()
         ]
-        correct_idx = sorted_ids.index(ex.synset_id)
+        correct_idx = next(
+            i for i, d in enumerate(definitions) if d.synset_id == ex.synset_id
+        )
         correct_letter = letters[correct_idx]
         prompt = create_multiple_choice_prompt(
             word=ex.word_form,

--- a/wsd/prompt.py
+++ b/wsd/prompt.py
@@ -56,18 +56,6 @@ class Definition:
     definition: str
 
 
-def get_option_letter(tokenizer: PreTrainedTokenizerBase, index: int) -> str:
-    """Return the i-th answer-letter for the given tokenizer.
-
-    The letter set is deterministic: letter_i is always the same for a given
-    tokenizer, so training and inference agree on the mapping.
-    """
-    letters = build_letters(tokenizer).letters
-    if index >= len(letters):
-        raise OptionLetterIndexError(index)
-    return letters[index]
-
-
 def create_marked_sentence(doc, target_position: int) -> str:
     """Create sentence with target word marked with asterisks"""
     text = ""

--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -7,7 +7,7 @@ from colorama import Fore, Style, init
 
 from wsd.env import WORDNET_URL
 from wsd.letters import NOTA_LETTER_INDEX
-from wsd.masked_language_model import load_model, unmask_token, unmask_token_batch
+from wsd.masked_language_model import load_model, unmask_token_batch
 from wsd.prompt import (
     NONE_OF_THE_ABOVE,
     Definition,
@@ -130,15 +130,15 @@ def _get_definitions_raw(queries: list[WordQuery], language: str = "en") -> list
 
         data = response.json()
 
-        # Parse response and maintain order
+        # Parse response and maintain order. Definitions are kept in the order
+        # returned by the API — typically WordNet's frequency order — so the
+        # more common senses land on earlier letter slots.
         results = []
         for item in data.get("data", []):
-            definitions = []
-            # Sort definitions by synset_id for consistent ordering
-            definitions_dict = item.get("definitions", {})
-            for synset_id in sorted(definitions_dict.keys()):
-                definition_text = definitions_dict[synset_id]
-                definitions.append(Definition(synset_id=synset_id, definition=definition_text))
+            definitions = [
+                Definition(synset_id=synset_id, definition=definition_text)
+                for synset_id, definition_text in item.get("definitions", {}).items()
+            ]
             results.append(definitions)
 
         # Validate response has correct number of items
@@ -231,51 +231,46 @@ def get_choice_probabilities(probs, definitions: list[Definition]) -> list[float
     return choice_probs
 
 
-def disambiguate_word(word: str, marked_sentence: str, definitions: list[Definition]) -> DisambiguationResult:
-    """Use ModernBERT to disambiguate word sense given context and definitions"""
-    if not definitions:
-        return DisambiguationResult(
-            synset_id=NO_DEFINITIONS_FOUND,
-            definition="",
-            confidence=0.0
-        )
+def _result_from_probs(
+    probs, definitions: list[Definition],
+) -> DisambiguationResult:
+    """Pick the best choice from ``probs`` and package it as a result.
 
-    components = load_model()
-
-    # Create multiple choice prompt
-    text = create_multiple_choice_prompt(
-        word, components.tokenizer.mask_token, marked_sentence, definitions, components.tokenizer,
-    )
-
-    # Get prediction
-    result = unmask_token(text)
-
-    # Get probabilities for all choices
-    choice_probs = get_choice_probabilities(result.probabilities, definitions)
-
-    # Find best choice and normalize
+    NOTA is indexed at ``len(definitions)`` in the ``choice_probs`` list (it's
+    the appended last entry), not at :data:`NOTA_LETTER_INDEX`; confidence is
+    renormalized over the valid choices only.
+    """
+    choice_probs = get_choice_probabilities(probs, definitions)
     best_choice_idx = choice_probs.index(max(choice_probs))
     total_prob = sum(choice_probs)
     normalized_score = choice_probs[best_choice_idx] / total_prob if total_prob > 0 else 0.0
 
-    # Handle "none of the above" case
-    if best_choice_idx == len(definitions):  # Next letter option selected
+    if best_choice_idx == len(definitions):  # NOTA slot
         return DisambiguationResult(
             synset_id="",
             definition=NONE_OF_THE_ABOVE,
-            confidence=normalized_score
+            confidence=normalized_score,
         )
-    else:
-        best_definition = definitions[best_choice_idx]
-        return DisambiguationResult(
-            synset_id=best_definition.synset_id,
-            definition=best_definition.definition,
-            confidence=normalized_score
-        )
+    best_definition = definitions[best_choice_idx]
+    return DisambiguationResult(
+        synset_id=best_definition.synset_id,
+        definition=best_definition.definition,
+        confidence=normalized_score,
+    )
+
+
+def disambiguate_word(
+    word: str, marked_sentence: str, definitions: list[Definition],
+) -> DisambiguationResult:
+    """Use ModernBERT to disambiguate word sense given context and definitions"""
+    results = disambiguate_word_batch(
+        [DisambiguationInput(word=word, marked_sentence=marked_sentence, definitions=definitions)]
+    )
+    return results[0]
 
 
 def disambiguate_word_batch(
-        batch_data: list[DisambiguationInput]
+        batch_data: list[DisambiguationInput],
 ) -> list[DisambiguationResult]:
     """
     Batch version of disambiguate_word that processes multiple words in parallel.
@@ -321,52 +316,18 @@ def disambiguate_word_batch(
     batch_results = unmask_token_batch(prompts)
 
     # Process results
+    valid_set = set(valid_indices)
     results = []
     result_idx = 0
     for i, input_obj in enumerate(batch_data):
-        if i not in valid_indices:
-            # No definitions for this word
-            results.append(
-                DisambiguationResult(
-                    synset_id=NO_DEFINITIONS_FOUND,
-                    definition="",
-                    confidence=0.0
-                )
-            )
-        else:
-            # Process the prediction for this word
-            unmask_result = batch_results[result_idx]
-            result_idx += 1
-
-            # Get probabilities for all choices
-            choice_probs = get_choice_probabilities(
-                unmask_result.probabilities,
-                input_obj.definitions,
-            )
-            # Find best choice and normalize
-            best_choice_idx = choice_probs.index(max(choice_probs))
-            total_prob = sum(choice_probs)
-            normalized_score = choice_probs[best_choice_idx] / total_prob if total_prob > 0 else 0.0
-
-            # Handle "none of the above" case
-            if best_choice_idx == len(input_obj.definitions):  # Next letter option selected
-                results.append(
-                    DisambiguationResult(
-                        synset_id="",
-                        definition=NONE_OF_THE_ABOVE,
-                        confidence=normalized_score
-                    )
-                )
-            else:
-                best_definition = input_obj.definitions[best_choice_idx]
-                results.append(
-                    DisambiguationResult(
-                        synset_id=best_definition.synset_id,
-                        definition=best_definition.definition,
-                        confidence=normalized_score
-                    )
-                )
-
+        if i not in valid_set:
+            results.append(DisambiguationResult(
+                synset_id=NO_DEFINITIONS_FOUND, definition="", confidence=0.0,
+            ))
+            continue
+        unmask_result = batch_results[result_idx]
+        result_idx += 1
+        results.append(_result_from_probs(unmask_result.probabilities, input_obj.definitions))
     return results
 
 


### PR DESCRIPTION
## Summary
- **Preserve API order.** Drop the `sorted(...)` over synset_ids in both `_get_definitions_raw` (inference) and `build_eval_examples_from_wn` (training eval). The API / wn library already returns definitions in frequency order, so the more common sense now lands on the earliest letter slot.
- **Dedupe NOTA + choice-prob handling.** Extract `_result_from_probs()` and collapse `disambiguate_word` into a single-element `disambiguate_word_batch` call. Fixes to NOTA detection / renormalization now only need to happen in one place.
- **Remove dead code.** `get_option_letter` had no callers; the unused `unmask_token` import goes with it.

## Test plan
- [ ] `ruff check wsd training` — passes locally
- [ ] Existing test suite runs green in CI
- [ ] Spot-check benchmark numbers haven't regressed (API-order vs synset-sorted order differs; frequency-first should be same-or-better)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the definition ordering used to assign answer letters in both training eval and inference, which can affect label/choice alignment and model accuracy. Also refactors disambiguation result selection/normalization, so bugs here would impact all predictions.
> 
> **Overview**
> Preserves the *API/WordNet iteration order* of definitions when building multiple-choice options, removing `sorted(...)` over `synset_id` in both training eval (`build_eval_examples_from_wn`) and inference (`_get_definitions_raw`) so earlier letters correspond to more frequent senses.
> 
> Refactors inference to dedupe “none of the above” and probability-to-result logic by introducing `_result_from_probs()` and routing `disambiguate_word` through `disambiguate_word_batch`; removes dead `get_option_letter` and the unused `unmask_token` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360e71b02aea34f42812e29721586c3c48b2cdd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved word sense disambiguation system with consolidated result-selection logic and streamlined batch processing workflow.
  * Reorganized definition ordering to align with API-provided sequence rather than custom sorting.
  * Simplified internal control flow and removed redundant helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->