### PR TITLE
train: eliminate A-letter bias via randomized option-block offset

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -131,6 +131,12 @@ def create_examples_for_synset(
     index_mapping = {old_idx: new_idx for new_idx, old_idx in enumerate(indices)}
 
     # Create one example for each sentence
+    letters = build_letters(tokenizer).letters
+    # Pick a random offset per sentence so the model sees correct answers
+    # spread across the whole letter range, not clustered near A. NOTA's slot
+    # at letters[NOTA_LETTER_INDEX] is fixed, so the options block must end
+    # before it.
+    max_offset = NOTA_LETTER_INDEX - len(shuffled_definitions)
     for sentence in synset["examples"]:
         try:
             marked_sentence = mark_word_in_sentence(sentence, word)
@@ -139,10 +145,12 @@ def create_examples_for_synset(
             # (e.g. "100" inside "100th"); skip so training matches inference.
             continue
 
+        start_offset = random.randint(0, max_offset) if max_offset > 0 else 0
+
         # Find correct answer after shuffling
         correct_original_idx = synset_to_definition[synset_id]
         correct_shuffled_idx = index_mapping[correct_original_idx]
-        correct_letter = build_letters(tokenizer).letters[correct_shuffled_idx]
+        correct_letter = letters[start_offset + correct_shuffled_idx]
 
         prompt = create_multiple_choice_prompt(
             word=word,
@@ -150,6 +158,7 @@ def create_examples_for_synset(
             marked_sentence=marked_sentence,
             definitions=shuffled_definitions,
             tokenizer=tokenizer,
+            start_offset=start_offset,
         )
 
         examples.append(TrainingExample(
@@ -229,12 +238,19 @@ def create_none_of_above_example(
     # The correct answer is "none of the above" — always the fixed NOTA letter.
     none_letter = build_letters(tokenizer).letters[NOTA_LETTER_INDEX]
 
+    # Random offset so NOTA examples also see the option block at varied
+    # positions — otherwise the model would learn "NOTA appears when options
+    # start at A" which is also a positional shortcut.
+    max_offset = NOTA_LETTER_INDEX - len(frequent_pos_definitions)
+    start_offset = random.randint(0, max_offset) if max_offset > 0 else 0
+
     prompt = create_multiple_choice_prompt(
         word=word,
         mask_token=tokenizer.mask_token,
         marked_sentence=marked_sentence,
         definitions=frequent_pos_definitions,
         tokenizer=tokenizer,
+        start_offset=start_offset,
     )
 
     return TrainingExample(

--- a/training/train.py
+++ b/training/train.py
@@ -702,7 +702,13 @@ def main():
         total = mask.sum()
         return {"accuracy": float(correct) / max(int(total), 1)}
 
+    # When eval is enabled we save at the same cadence so
+    # load_best_model_at_end can compare eval metrics to saved checkpoints
+    # and restore the best-accuracy one at the end of training.
     eval_enabled = eval_dataset is not None
+    save_strategy = "steps" if eval_enabled else (
+        "epoch" if config.max_steps == -1 else "steps"
+    )
     training_args = TrainingArguments(
         output_dir=str(config.output_dir),
         num_train_epochs=config.num_epochs,
@@ -717,8 +723,12 @@ def main():
         logging_steps=10,
         eval_strategy="steps" if eval_enabled else "no",
         eval_steps=config.eval_steps if eval_enabled else None,
-        save_strategy="epoch" if config.max_steps == -1 else "steps",
-        save_total_limit=1,
+        save_strategy=save_strategy,
+        save_steps=config.eval_steps if save_strategy == "steps" else None,
+        save_total_limit=2,
+        load_best_model_at_end=eval_enabled,
+        metric_for_best_model="accuracy" if eval_enabled else None,
+        greater_is_better=True if eval_enabled else None,
         bf16=torch.cuda.is_available(),
         dataloader_num_workers=0,
         report_to=config.report_to,

--- a/wsd/bias_probe.py
+++ b/wsd/bias_probe.py
@@ -1,0 +1,214 @@
+"""Probe whether the WSD model has a bias toward letter A (the first option).
+
+Training always lays definitions on letters[0], letters[1], ... so the model
+might be exploiting "the correct answer is one of the first few letters"
+rather than actually attending to each (letter, definition) pairing. This
+script shifts the entire option block to a non-zero ``start_offset`` and
+measures how benchmark accuracy degrades.
+
+The NOTA slot is held fixed at :data:`wsd.letters.NOTA_LETTER_INDEX` so that
+the model still has a familiar "reject" signal even when the options live at
+unfamiliar letters.
+
+Definitions are pulled directly from the ``wn`` library (same backend as
+``training.build_eval_examples_from_wn``) so this script is self-contained
+— no WordNet HTTP service required.
+
+Usage::
+
+    WORDNET_URL=NONE python -m wsd.bias_probe \\
+        --offsets 0 1 5 10 26 52 100 \\
+        --n-examples 1000 \\
+        --seed 42
+
+(``WORDNET_URL`` is only referenced at import time by wsd.env; a dummy value
+is fine here since we never hit the HTTP endpoint.)
+"""
+from __future__ import annotations
+
+import argparse
+import random
+from dataclasses import dataclass
+
+import wn
+from tqdm import tqdm
+
+from wsd.benchmark import WordNetExample, collect_wordnet_examples
+from wsd.letters import NOTA_LETTER_INDEX
+from wsd.prompt import Definition
+from wsd.word_sense_disambiguation import (
+    DisambiguationInput,
+    disambiguate_word_batch,
+)
+
+
+@dataclass
+class OffsetResult:
+    offset: int
+    n_evaluated: int  # examples whose option count fit under the offset
+    n_skipped: int    # examples skipped because offset + len(defs) > NOTA
+    n_correct: int
+    n_nota: int       # times the model said "none of the above"
+
+    @property
+    def accuracy(self) -> float:
+        return self.n_correct / self.n_evaluated if self.n_evaluated else 0.0
+
+
+def _load_wn():
+    """Load or download the omw-en:1.4 lexicon."""
+    try:
+        return wn.Wordnet(lexicon="omw-en:1.4")
+    except wn.Error:
+        wn.download("omw-en:1.4")
+        return wn.Wordnet(lexicon="omw-en:1.4")
+
+
+def _fetch_definitions_for_example(
+    en: wn.Wordnet, ex: WordNetExample,
+) -> list[Definition] | None:
+    """Mirror build_eval_examples_from_wn's lookup: fetch defs for (lemma, pos).
+
+    Returns None when the example's own synset isn't in the wn lookup (can
+    happen when the lexicon disagrees with the example's metadata), or when
+    there are no definitions at all.
+    """
+    pos_options = {"a", "s"} if ex.pos == "a" else {ex.pos}
+    defs: dict[str, str] = {}
+    for word in en.words(form=ex.lemma):
+        for synset in word.synsets():
+            if synset.pos not in pos_options:
+                continue
+            text = synset.definition()
+            if text:
+                defs[synset.id] = text
+    if ex.synset_id not in defs:
+        return None
+    return [Definition(synset_id=sid, definition=text) for sid, text in defs.items()]
+
+
+def _sample_examples_with_defs(
+    n_examples: int, seed: int,
+) -> tuple[list[WordNetExample], list[list[Definition]]]:
+    """Sample ``n_examples`` and fetch their definitions once (reused across offsets)."""
+    en = _load_wn()
+
+    all_examples = list(collect_wordnet_examples())
+    rng = random.Random(seed)
+    rng.shuffle(all_examples)
+
+    out_ex: list[WordNetExample] = []
+    out_defs: list[list[Definition]] = []
+    for ex in all_examples:
+        defs = _fetch_definitions_for_example(en, ex)
+        if defs is None:
+            continue
+        out_ex.append(ex)
+        out_defs.append(defs)
+        if len(out_ex) >= n_examples:
+            break
+    return out_ex, out_defs
+
+
+def _evaluate_at_offset(
+    examples: list[WordNetExample],
+    all_definitions: list[list[Definition]],
+    offset: int,
+    batch_size: int,
+) -> OffsetResult:
+    """Run batched disambiguation at a single offset and count correctness."""
+    # Skip any example whose option block would collide with NOTA at this offset.
+    pairs = [
+        (ex, defs) for ex, defs in zip(examples, all_definitions, strict=True)
+        if offset + len(defs) <= NOTA_LETTER_INDEX
+    ]
+    skipped = len(examples) - len(pairs)
+
+    correct = 0
+    nota = 0
+    for start in tqdm(
+        range(0, len(pairs), batch_size), desc=f"offset={offset}", leave=False,
+    ):
+        chunk = pairs[start : start + batch_size]
+        batch = [
+            DisambiguationInput(
+                word=ex.word_form, marked_sentence=ex.marked_text, definitions=defs,
+            )
+            for ex, defs in chunk
+        ]
+        preds = disambiguate_word_batch(batch, start_offset=offset)
+        for (ex, _), pred in zip(chunk, preds, strict=True):
+            if pred.synset_id == ex.synset_id:
+                correct += 1
+            if pred.synset_id == "":  # NOTA
+                nota += 1
+
+    return OffsetResult(
+        offset=offset,
+        n_evaluated=len(pairs),
+        n_skipped=skipped,
+        n_correct=correct,
+        n_nota=nota,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--offsets", type=int, nargs="+",
+        default=[0, 1, 5, 10, 26, 52, 100],
+        help="Letter-offset values to evaluate (each must leave room for NOTA).",
+    )
+    parser.add_argument(
+        "--n-examples", type=int, default=1000,
+        help="Number of wn examples to sample (deterministic given --seed).",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="Sampling seed for example selection.",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=32,
+        help="Inference batch size.",
+    )
+    args = parser.parse_args()
+
+    print(f"Sampling {args.n_examples} examples (seed={args.seed})...")
+    examples, all_definitions = _sample_examples_with_defs(args.n_examples, args.seed)
+    print(
+        f"Got {len(examples)} examples with definitions "
+        f"(min defs per example = {min(len(d) for d in all_definitions)}, "
+        f"max = {max(len(d) for d in all_definitions)})."
+    )
+
+    results: list[OffsetResult] = []
+    for offset in args.offsets:
+        r = _evaluate_at_offset(examples, all_definitions, offset, args.batch_size)
+        results.append(r)
+        print(
+            f"offset={offset:>4}  "
+            f"acc={r.accuracy:.4f}  "
+            f"n={r.n_evaluated}  "
+            f"skipped={r.n_skipped}  "
+            f"nota={r.n_nota}"
+        )
+
+    # Final table
+    print("\n" + "=" * 72)
+    print(f"{'offset':>8} {'accuracy':>10} {'n':>8} {'skipped':>10} {'nota':>8}")
+    print("=" * 72)
+    for r in results:
+        print(
+            f"{r.offset:>8} {r.accuracy:>10.4f} {r.n_evaluated:>8} "
+            f"{r.n_skipped:>10} {r.n_nota:>8}"
+        )
+    base = next((r.accuracy for r in results if r.offset == 0), None)
+    if base is not None:
+        print("\nDelta vs offset=0:")
+        for r in results:
+            delta = r.accuracy - base
+            print(f"  offset={r.offset:>4}: {delta:+.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/wsd/prompt.py
+++ b/wsd/prompt.py
@@ -72,21 +72,26 @@ def create_multiple_choice_prompt(word: str,
                                   mask_token: str,
                                   marked_sentence: str,
                                   definitions: list[Definition],
-                                  tokenizer: PreTrainedTokenizerBase) -> str:
+                                  tokenizer: PreTrainedTokenizerBase,
+                                  start_offset: int = 0) -> str:
     """Create multiple choice prompt for word sense disambiguation.
 
+    ``definitions[i]`` is rendered with letter ``start_offset + i``; the
+    default ``start_offset=0`` keeps the historical "A, B, C, ..." layout.
+    Non-zero offsets are used by the bias probe to test whether the model
+    depends on the specific A-first mapping it saw during training.
+
     The last letter (index :data:`wsd.letters.NOTA_LETTER_INDEX`) is always
-    reserved for the "none of the above" option, so it's a stable reject
-    signal across all prompts. At most ``NOTA_LETTER_INDEX`` definitions may
-    be passed (they occupy letters 0..NOTA_LETTER_INDEX-1).
+    reserved for the "none of the above" option. The offset window must not
+    collide with NOTA: ``start_offset + len(definitions) <= NOTA_LETTER_INDEX``.
     """
     letters = build_letters(tokenizer).letters
-    if len(definitions) > NOTA_LETTER_INDEX:
-        raise OptionLetterIndexError(len(definitions))
+    if start_offset < 0 or start_offset + len(definitions) > NOTA_LETTER_INDEX:
+        raise OptionLetterIndexError(start_offset + len(definitions))
 
     choices = []
     for i, definition_obj in enumerate(definitions):
-        letter = letters[i]
+        letter = letters[start_offset + i]
         choices.append(f"{letter}. {definition_obj.definition}")
 
     # NOTA always uses the reserved last letter, regardless of how many

--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -218,21 +218,24 @@ def get_definitions_single(word: str, pos: str, language: str = "en") -> list[De
     return results[0] if results else []
 
 
-def get_choice_probabilities(probs, definitions: list[Definition]) -> list[float]:
+def get_choice_probabilities(
+    probs, definitions: list[Definition], start_offset: int = 0,
+) -> list[float]:
     """Get probabilities for all choice letters including 'none of the above'.
 
     With a pruned decoder, logits (and therefore ``probs``) are already laid out
-    in answer-letter order: ``probs[i]`` is the probability of letter_i, which
-    is exactly the i-th choice in the prompt. NOTA always lives at the fixed
-    index :data:`wsd.letters.NOTA_LETTER_INDEX`.
+    in answer-letter order. ``definitions[i]`` occupies letter
+    ``start_offset + i``; NOTA always lives at the fixed index
+    :data:`wsd.letters.NOTA_LETTER_INDEX`. The returned list has one entry per
+    definition followed by the NOTA probability.
     """
-    choice_probs = [float(probs[i]) for i in range(len(definitions))]
+    choice_probs = [float(probs[start_offset + i]) for i in range(len(definitions))]
     choice_probs.append(float(probs[NOTA_LETTER_INDEX]))  # "none of the above"
     return choice_probs
 
 
 def _result_from_probs(
-    probs, definitions: list[Definition],
+    probs, definitions: list[Definition], start_offset: int = 0,
 ) -> DisambiguationResult:
     """Pick the best choice from ``probs`` and package it as a result.
 
@@ -240,7 +243,7 @@ def _result_from_probs(
     the appended last entry), not at :data:`NOTA_LETTER_INDEX`; confidence is
     renormalized over the valid choices only.
     """
-    choice_probs = get_choice_probabilities(probs, definitions)
+    choice_probs = get_choice_probabilities(probs, definitions, start_offset)
     best_choice_idx = choice_probs.index(max(choice_probs))
     total_prob = sum(choice_probs)
     normalized_score = choice_probs[best_choice_idx] / total_prob if total_prob > 0 else 0.0
@@ -260,17 +263,22 @@ def _result_from_probs(
 
 
 def disambiguate_word(
-    word: str, marked_sentence: str, definitions: list[Definition],
+    word: str,
+    marked_sentence: str,
+    definitions: list[Definition],
+    start_offset: int = 0,
 ) -> DisambiguationResult:
     """Use ModernBERT to disambiguate word sense given context and definitions"""
     results = disambiguate_word_batch(
-        [DisambiguationInput(word=word, marked_sentence=marked_sentence, definitions=definitions)]
+        [DisambiguationInput(word=word, marked_sentence=marked_sentence, definitions=definitions)],
+        start_offset=start_offset,
     )
     return results[0]
 
 
 def disambiguate_word_batch(
         batch_data: list[DisambiguationInput],
+        start_offset: int = 0,
 ) -> list[DisambiguationResult]:
     """
     Batch version of disambiguate_word that processes multiple words in parallel.
@@ -297,6 +305,7 @@ def disambiguate_word_batch(
                 input_obj.marked_sentence,
                 input_obj.definitions,
                 components.tokenizer,
+                start_offset=start_offset,
             )
             prompts.append(text)
             valid_indices.append(i)
@@ -327,7 +336,9 @@ def disambiguate_word_batch(
             continue
         unmask_result = batch_results[result_idx]
         result_idx += 1
-        results.append(_result_from_probs(unmask_result.probabilities, input_obj.definitions))
+        results.append(_result_from_probs(
+            unmask_result.probabilities, input_obj.definitions, start_offset=start_offset,
+        ))
     return results
 
 


### PR DESCRIPTION
## Problem

The decoder had learned a positional shortcut: *"the answer lives in the first few letters."* Because training always laid definitions on letters `[A, B, C, …]` starting at index 0, the model could classify without truly attending to each `(letter, definition)` pair.

A new probe script (`wsd/bias_probe.py`) quantifies this by shifting the option block to a non-zero `start_offset` (NOTA stays pinned at its reserved slot). On the previously-released checkpoint:

| offset | accuracy | NOTA preds |
|-------:|:--------:|:---------:|
| 0      | 66.30%   | 39 / 1000 |
| 1      | 64.50%   | 61        |
| 5      | 50.80%   | 249       |
| 10     | 28.00%   | 588       |
| 26     | 2.30%    | 950       |
| 52     | 0.00%    | 997       |
| 100    | 0.00%    | 980       |

Accuracy collapses entirely once options move past letter 10; nearly every prediction becomes NOTA.

## Fix

`training/train.py`: for each training sentence, sample a random `start_offset ∈ [0, NOTA_LETTER_INDEX − len(definitions)]` and position the option block there. The correct-answer letter is translated accordingly (`letters[start_offset + shuffled_idx]`). NOTA-training examples get the same treatment for their option block (the target letter is still the fixed NOTA slot at index 127).

Eval remains at `start_offset=0` (`build_eval_examples_from_wn` defaults) so eval metrics stay comparable to real inference.

## Results

After retraining one epoch with the fix:

| offset | before | after | Δ |
|-------:|:------:|:-----:|:---:|
| 0      | 66.30% | **66.20%** | −0.1 |
| 1      | 64.50% | 67.10% | +2.6 |
| 5      | 50.80% | 66.80% | +16.0 |
| 10     | 28.00% | 66.90% | +38.9 |
| 26     | 2.30%  | 66.40% | +64.1 |
| 52     | 0.00%  | 65.20% | +65.2 |
| 100    | 0.00%  | 67.24% | +67.2 |

All offsets within ±1% of offset=0. NOTA predictions 24–39 across the board instead of 39 → 997. Real-inference accuracy (offset=0) is unchanged.

## Scope

This PR stacks three commits; #9 is the first of them, so merging this after #9 will leave just the probe + training fix:

- `refactor: preserve API definition order; dedupe NOTA handling; remove dead code` *(= #9)*
- `probe: add letter-shift bias probe with start_offset` — probe script + `start_offset` plumbed through `create_multiple_choice_prompt` and `disambiguate_word_batch`
- `train: randomize letter start_offset per example to break A-bias` — the core fix

## Test plan

- [x] 20-step dry-run training with the new offset logic (syntax + shape check)
- [x] Full 1-epoch retraining on GB10 (~2h 34min, loss 0.93 vs 0.43 for the biased run — expected, harder task)
- [x] `wsd.bias_probe` at offsets {0, 1, 5, 10, 26, 52, 100} — all within ±1% of offset=0
- [ ] Run benchmark on the trained checkpoint (optional, but offset=0 probe result already confirms accuracy is preserved)
- [ ] Push the trained checkpoint to HF hub (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt/decoding to support shifted answer-letter blocks and randomizes training offsets, which can affect model-label alignment if offsets/definition counts are mishandled. Also alters checkpoint saving/eval behavior to load best model at end, impacting training outputs.
> 
> **Overview**
> **Breaks the model’s positional “A/B/C…” shortcut** by introducing a `start_offset` for multiple-choice options.
> 
> Training now samples a per-example random `start_offset` (bounded to avoid the fixed NOTA slot) and shifts both prompt rendering and the computed correct-answer letter accordingly, including for NOTA training examples. Inference/plumbing is extended end-to-end (`create_multiple_choice_prompt`, `disambiguate_word(_batch)`, and probability indexing) so callers can evaluate or run with non-zero offsets.
> 
> Adds a standalone `wsd/bias_probe.py` script that samples WordNet examples via `wn` and measures accuracy across different offsets, and updates training checkpointing to save on the eval cadence and optionally `load_best_model_at_end` based on eval accuracy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb01a446418db1c29b87ae94c2ec35290050001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bias probe benchmarking tool to measure word sense disambiguation accuracy under varying answer option positions.
  * Implemented randomization of answer option letter positions in training examples and disambiguation tasks.

* **Improvements**
  * Updated disambiguation functions to support flexible answer option positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->