### PR TITLE
fix(wsd): add timeout to WordNet API request

### DIFF
--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -122,7 +122,7 @@ def _get_definitions_raw(queries: list[WordQuery], language: str = "en") -> list
     }
 
     try:
-        response = requests.post(url, json=payload)
+        response = requests.post(url, json=payload, timeout=30)
 
         if response.status_code != 200:
             print(f"Error: API returned status code {response.status_code}")


### PR DESCRIPTION
## Summary
- `requests.post` in `_get_definitions_raw` had no timeout, so a hung WordNet server would hang the disambiguation pipeline indefinitely.
- `training/data/generate.py` already uses an explicit timeout; mirror that pattern on the serving hot path with a shorter 30s budget.

## Test plan
- [ ] Existing `test_get_definitions_*` tests still pass (unchanged behavior on successful mocks; `RequestException` path catches `Timeout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only adds a 30s timeout to the WordNet definition fetch, reducing the chance the WSD pipeline hangs on a stalled upstream request.
> 
> **Overview**
> Adds a `timeout=30` to the WordNet batch `requests.post` call in `_get_definitions_raw` so definition lookups fail fast instead of potentially hanging indefinitely when the upstream service stalls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef83a185f29e12f07a7a2782b85d2ca705d420e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling for definition fetching by implementing a 30-second timeout. This prevents the system from waiting indefinitely when retrieving word definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->