### PR TITLE
perf(cuda): move mask detection to CPU to keep stream dispatch async

### DIFF
--- a/wsd/masked_language_model.py
+++ b/wsd/masked_language_model.py
@@ -159,33 +159,32 @@ def _unmask_chunks_cuda_parallel(
     chunks: list[tuple[list[int], list[str]]],
     components: ModelComponents,
 ) -> list[list[UnmaskResult]]:
-    """Dispatch each chunk on its own CUDA stream, sync, and return results.
+    """Dispatch each chunk's forward pass on its own CUDA stream.
 
-    Splits the per-chunk work into a forward pass (enqueued on the chunk's
-    stream) and a host-side finalize step (softmax+argmax) that runs only
-    after the stream has synchronized. The argmax is tiny but launches a
-    kernel, so we keep it on the stream too; only the final ``.item()`` and
-    Python list construction wait for the GPU.
+    Tokenization and mask-position lookup run on CPU before we enter the
+    stream context. Doing the lookup on-GPU would require a ``.item()``
+    sync that waits for the chunk's own stream to drain, which serialized
+    the per-chunk dispatch with the host and erased most of the stream
+    parallelism. On CPU the lookup is ~microseconds per chunk.
     """
+    mask_id = components.tokenizer.mask_token_id
     streams = [torch.cuda.Stream() for _ in chunks]
     pending: list[tuple[list[tuple[torch.Tensor, int]], torch.cuda.Stream]] = []
 
     for (_, chunk_texts), stream in zip(chunks, streams, strict=True):
+        cpu_inputs = components.tokenizer(
+            chunk_texts, return_tensors="pt", padding=True,
+        )
+        mask_positions: list[tuple[int, int]] = []
+        for i in range(len(chunk_texts)):
+            positions = (cpu_inputs.input_ids[i] == mask_id).nonzero(as_tuple=True)[0]
+            if positions.numel() == 0:
+                raise PromptMaskError()
+            mask_positions.append((i, int(positions[0])))
+
         with torch.cuda.stream(stream), torch.no_grad():
-            inputs = components.tokenizer(
-                chunk_texts, return_tensors="pt", padding=True,
-            ).to(components.device)
-
-            mask_positions = []
-            for i in range(len(chunk_texts)):
-                mask_idx = (inputs.input_ids[i] == components.tokenizer.mask_token_id).nonzero()
-                if len(mask_idx) == 0:
-                    raise PromptMaskError()
-                mask_positions.append((i, mask_idx[0, 0].item()))
-
+            inputs = cpu_inputs.to(components.device, non_blocking=True)
             outputs = components.model(**inputs)
-            # Keep only the logits we need per example (tiny slice), still on
-            # the chunk's stream.
             logits_per_example = [
                 (outputs.logits[bi, si], bi) for bi, si in mask_positions
             ]


### PR DESCRIPTION
## Summary
- The previous parallel-stream path called `.item()` on a CUDA tensor *inside* each chunk's stream context, which forced the host to wait for that chunk's nonzero/indexing ops to drain before the forward pass could be enqueued. The streams still overlapped eventually, but a lot of the win was eaten by these per-chunk syncs.
- Tokenization and mask-position lookup are tiny; run them on CPU before entering the stream context. H2D copy is enqueued non-blocking on the chunk's stream together with the forward pass, so nothing between `.to(device)` and `stream.synchronize()` touches the host.

## Test plan
- [ ] `test_unmask_token_batch_preserves_order_with_varied_lengths` still passes (exercises the multi-chunk path and order remap).
- [ ] Re-measure throughput on GB10 at bs=32 to confirm the overlap win now materializes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CUDA multi-stream batching path to do mask-position detection on CPU and use non-blocking H2D copies; main risk is subtle correctness/perf regressions in the async stream scheduling and mask indexing behavior on GPU.
> 
> **Overview**
> Improves CUDA performance for `unmask_token_batch`’s multi-chunk path by moving tokenization and mask-position lookup out of the CUDA stream context and onto the CPU, avoiding per-chunk `.item()` synchronizations that were serializing dispatch.
> 
> Within `_unmask_chunks_cuda_parallel`, each chunk now tokenizes on CPU, finds the first mask index per example from CPU tensors, then enqueues a non-blocking `.to(device)` plus the model forward pass on the chunk’s stream before synchronizing only when collecting final probabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7abde6db306fdef666c6d590bc415dbbc4144d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->