### PR TITLE
fix(letters): drop '*' and apostrophe from safe_symbols pool

### DIFF
--- a/wsd/letters.py
+++ b/wsd/letters.py
@@ -39,8 +39,11 @@ def _candidate_pools() -> list[list[str]]:
     """
     latin = list(string.ascii_uppercase + string.ascii_lowercase)
     digits = list(string.digits)
-    # '.' and other format-significant punctuation excluded (clashes with "A. " template)
-    safe_symbols = list("!@#$%^&*+=<>?/|~`'()[]{}_-")
+    # Excluded:
+    #   '.' — clashes with the "A. " option template
+    #   '*' — clashes with the *word* marker in marked sentences
+    #   "'" — rendered option "'. def" is visually ambiguous with contractions
+    safe_symbols = list("!@#$%^&+=<>?/|~`()[]{}_-")
     greek_upper = [chr(c) for c in range(0x0391, 0x03A9 + 1) if c != 0x03A2]
     greek_lower = [chr(c) for c in range(0x03B1, 0x03C9 + 1)]
     cyrillic_upper = [chr(c) for c in range(0x0410, 0x042F + 1)]


### PR DESCRIPTION
## Summary
- `*` is already used as the word-marker in marked sentences; letting it also serve as an answer letter would make the two roles ambiguous if Latin+digits ever fail to saturate the 128 slots.
- Apostrophe removed for the same class of concern: rendered \`'. definition\` visually collides with English contractions.
- Currently latent on ModernBERT (Latin pool saturates), but any tokenizer swap could trip it.

## Test plan
- [ ] \`test_letters.py\` still passes — Latin pool still comes first, so the public ordering invariants are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tweaks the fallback character pool for option-letter selection to avoid ambiguity with `*word*` markers and apostrophes; behavior is unchanged for tokenizers that already fill from Latin/digits.
> 
> **Overview**
> Prevents ambiguous answer-letter characters by excluding `*` (conflicts with `*word*` markers in marked sentences) and `'` (can visually blend into contractions) from the `safe_symbols` pool in `wsd/letters.py`.
> 
> This only affects letter selection if the tokenizer can’t fill `NUM_LETTERS` from higher-priority pools (Latin and digits), tightening the fallback set without changing the overall ordering strategy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241b0f3654d29c8d0e30db3294c336ecdfdc1156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->