### PR TITLE
fix(prompt): distinct error class for already-marked sentence

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -31,6 +31,7 @@ from wsd.model import WSDModernBertForMaskedLM
 from wsd.model_surgery import prune_decoder
 from wsd.prompt import (
     Definition,
+    SentenceAlreadyMarkedError,
     WordNotFoundError,
     create_multiple_choice_prompt,
     mark_word_in_sentence,
@@ -140,9 +141,10 @@ def create_examples_for_synset(
     for sentence in synset["examples"]:
         try:
             marked_sentence = mark_word_in_sentence(sentence, word)
-        except WordNotFoundError:
+        except (WordNotFoundError, SentenceAlreadyMarkedError):
             # Sentence doesn't contain the word with clean word boundaries
-            # (e.g. "100" inside "100th"); skip so training matches inference.
+            # (e.g. "100" inside "100th"), or the sentence already uses '*';
+            # skip so training matches inference.
             continue
 
         start_offset = random.randint(0, max_offset) if max_offset > 0 else 0
@@ -213,7 +215,7 @@ def create_none_of_above_example(
     for s, ex in candidate_sentences:
         try:
             marked_sentence = mark_word_in_sentence(ex, word)
-        except WordNotFoundError:
+        except (WordNotFoundError, SentenceAlreadyMarkedError):
             continue
         chosen_synset = s
         chosen_sentence = ex

--- a/wsd/benchmark.py
+++ b/wsd/benchmark.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import wn
 from tqdm import tqdm
 
-from wsd.prompt import WordNotFoundError, mark_word_in_sentence
+from wsd.prompt import SentenceAlreadyMarkedError, WordNotFoundError, mark_word_in_sentence
 from wsd.word_sense_disambiguation import (
     DisambiguationInput,
     WordQuery,
@@ -52,7 +52,7 @@ def collect_wordnet_examples():
                 for example in examples:
                     try:
                         marked_text = mark_word_in_sentence(example, form)
-                    except WordNotFoundError:
+                    except (WordNotFoundError, SentenceAlreadyMarkedError):
                         continue
                     yield WordNetExample(
                         synset.id, form, word.lemma(), word.pos, marked_text, example

--- a/wsd/prompt.py
+++ b/wsd/prompt.py
@@ -16,6 +16,13 @@ class WordNotFoundError(ValueError):
         self.sentence = sentence
 
 
+class SentenceAlreadyMarkedError(ValueError):
+    """Raised when *sentence* already contains the ``*`` marker character."""
+    def __init__(self, sentence: str):
+        super().__init__(f"Sentence already contains marker character '*': {sentence!r}")
+        self.sentence = sentence
+
+
 def mark_word_in_sentence(sentence: str, word: str) -> str:
     """Mark the first word-boundary occurrence of *word* in *sentence* with asterisks.
 
@@ -26,12 +33,12 @@ def mark_word_in_sentence(sentence: str, word: str) -> str:
     training data generation and benchmark/inference paths; identical output
     here means identical prompts.
 
-    Raises ``WordNotFoundError`` if no word-boundary match is found, or if
-    *sentence* already contains an asterisk (which would be ambiguous with
-    our marker character).
+    Raises ``SentenceAlreadyMarkedError`` if the sentence already contains an
+    asterisk, or ``WordNotFoundError`` if no word-boundary match is found.
+    Both subclass ``ValueError`` so existing catch-all handlers keep working.
     """
     if "*" in sentence:
-        raise WordNotFoundError(word, sentence)
+        raise SentenceAlreadyMarkedError(sentence)
     pattern = r"\b" + re.escape(word) + r"\b"
     match = re.search(pattern, sentence, flags=re.IGNORECASE)
     if match is None:


### PR DESCRIPTION
## Summary
- \`mark_word_in_sentence\` previously reused \`WordNotFoundError\` for the "sentence already contains '*'" case, with a message that claimed the word wasn't found. Split out \`SentenceAlreadyMarkedError\` so the failure names its actual cause.
- Updated call sites (\`benchmark.py\`, \`train.py\`) to catch both — same behavior (skip example), clearer semantics.

## Test plan
- [ ] Existing \`mark_word_in_sentence\` tests still pass for the "word not found" path.
- [ ] Add a focused test that a sentence containing '*' raises \`SentenceAlreadyMarkedError\`, not \`WordNotFoundError\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to error typing/handling around prompt marking, with call sites updated to preserve existing skip behavior.
> 
> **Overview**
> Adds `SentenceAlreadyMarkedError` and updates `mark_word_in_sentence` to raise it (instead of `WordNotFoundError`) when the input sentence already contains `*`, making failure causes explicit.
> 
> Updates `training/train.py` and `wsd/benchmark.py` to catch both `WordNotFoundError` and `SentenceAlreadyMarkedError` and continue skipping those examples, keeping behavior the same while improving semantics and messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87e033c0eb12ef101189fcef4aa5a60253798669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->