### PR TITLE
fix(train): guard compute_metrics against sparse_prediction shape change

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -531,6 +531,27 @@ def print_gpu_memory():
         print(f"  Device {i}: {allocated:.2f} GB allocated, {reserved:.2f} GB reserved")
 
 
+class SparsePredictionEnabledError(RuntimeError):
+    """Raised when sparse_prediction is on — it breaks compute_metrics' shape assumptions."""
+    def __init__(self):
+        super().__init__(
+            "compute_metrics assumes dense (batch, seq_len, vocab) logits, "
+            "but model.config.sparse_prediction=True returns (num_masks, vocab). "
+            "Set config.sparse_prediction=False before training."
+        )
+
+
+def _assert_dense_logits(model) -> None:
+    # compute_metrics/preprocess_logits_for_metrics below assume dense logits of
+    # shape (batch, seq_len, vocab). ModernBERT's ``sparse_prediction`` mode
+    # filters to (num_masks, vocab), which would make ``predictions`` collapse
+    # to (num_masks,) while ``labels`` stays (batch, seq_len) — the equality
+    # check would then broadcast incorrectly and report a silently-wrong
+    # accuracy.
+    if getattr(model.config, "sparse_prediction", False):
+        raise SparsePredictionEnabledError()
+
+
 def print_sample_example(example: TrainingExample):
     """Print a sample training example."""
     print("\n" + "=" * 80)
@@ -692,19 +713,7 @@ def main():
     # Accuracy on the held-out eval set, measured only at mask positions.
     # preprocess_logits_for_metrics keeps only the argmax per position so we
     # don't accumulate (N, L, V) logits across the entire eval set.
-    #
-    # This shape contract assumes the model returns dense logits of shape
-    # (batch, seq_len, vocab). ModernBERT's ``sparse_prediction`` mode filters
-    # those to (num_masks, vocab) before returning, which would make
-    # ``predictions`` collapse to (num_masks,) while ``labels`` stays
-    # (batch, seq_len) — the equality check in compute_metrics would then
-    # broadcast incorrectly. Assert the mode is off rather than accept a
-    # silently-wrong accuracy number.
-    if getattr(model.config, "sparse_prediction", False):
-        raise RuntimeError(
-            "compute_metrics assumes dense logits; "
-            "set config.sparse_prediction=False before training."
-        )
+    _assert_dense_logits(model)
 
     def preprocess_logits_for_metrics(logits, labels):
         return logits.argmax(dim=-1)

--- a/training/train.py
+++ b/training/train.py
@@ -692,6 +692,20 @@ def main():
     # Accuracy on the held-out eval set, measured only at mask positions.
     # preprocess_logits_for_metrics keeps only the argmax per position so we
     # don't accumulate (N, L, V) logits across the entire eval set.
+    #
+    # This shape contract assumes the model returns dense logits of shape
+    # (batch, seq_len, vocab). ModernBERT's ``sparse_prediction`` mode filters
+    # those to (num_masks, vocab) before returning, which would make
+    # ``predictions`` collapse to (num_masks,) while ``labels`` stays
+    # (batch, seq_len) — the equality check in compute_metrics would then
+    # broadcast incorrectly. Assert the mode is off rather than accept a
+    # silently-wrong accuracy number.
+    if getattr(model.config, "sparse_prediction", False):
+        raise RuntimeError(
+            "compute_metrics assumes dense logits; "
+            "set config.sparse_prediction=False before training."
+        )
+
     def preprocess_logits_for_metrics(logits, labels):
         return logits.argmax(dim=-1)
 


### PR DESCRIPTION
## Summary
- \`compute_metrics\` assumes dense \`(batch, seq_len, vocab)\` logits. ModernBERT's \`sparse_prediction\` mode collapses that to \`(num_masks, vocab)\`, which would make predictions shape \`(num_masks,)\` while labels stay \`(batch, seq_len)\` — the equality check then broadcasts and the accuracy number goes silently wrong.
- Current checkpoints ship with \`sparse_prediction: false\`, so this is latent. Assert it rather than let a future flip produce meaningless metrics.

## Test plan
- [ ] Training still starts with the default config (\`sparse_prediction=False\`).
- [ ] Setting \`sparse_prediction=True\` on the config now raises a clear error before the Trainer is constructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple runtime guard and clearer error to prevent silently incorrect accuracy when `model.config.sparse_prediction` is enabled; no training logic is otherwise changed.
> 
> **Overview**
> Adds a fail-fast guard in `training/train.py` to prevent evaluation metrics from running when `model.config.sparse_prediction=True` would change logits from dense `(batch, seq_len, vocab)` to sparse `(num_masks, vocab)`.
> 
> Introduces `SparsePredictionEnabledError` and `_assert_dense_logits(model)`, and calls the assertion before defining `preprocess_logits_for_metrics`/`compute_metrics` so training errors early instead of reporting silently wrong accuracy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745e90b46b87981b434ef61428ac12df91c7fc24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->