### PR TITLE
perf(inference): prefer bf16 over fp16 when the GPU supports it

### DIFF
--- a/wsd/masked_language_model.py
+++ b/wsd/masked_language_model.py
@@ -49,10 +49,18 @@ def load_model(model_name: str = _DEFAULT_MODEL) -> ModelComponents:
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     letter_set = build_letters(tokenizer)
 
+    # Prefer bf16 on GPUs that support it (Ampere+, most AMD MI200+) — it
+    # matches the dtype training uses, so inference doesn't incur a numeric
+    # mismatch versus the trained weights. Fall back to fp16 on older GPUs.
+    if device == "cuda":
+        dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+    else:
+        dtype = None
+
     model = WSDModernBertForMaskedLM.from_pretrained(
         model_name,
         device_map=device,
-        dtype=torch.float16 if device == "cuda" else None,
+        dtype=dtype,
     )
     # Stock checkpoints ship with a full-vocab decoder; prune it to the 128
     # answer letters so decoder outputs are indexed by compact ids. Checkpoints


### PR DESCRIPTION
## Summary
- Training runs in bf16, inference was hard-coded to fp16 — a small numeric mismatch versus the dtype the weights were trained in.
- Use \`torch.cuda.is_bf16_supported()\` to pick bf16 on Ampere+/MI200+, fall back to fp16 on older GPUs, and keep non-CUDA devices unchanged.

## Test plan
- [ ] \`load_model\` loads on a bf16-capable GPU at bf16.
- [ ] \`test_unmask_token_returns_answer_letter\` and friends still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the only behavioral change is CUDA model load dtype selection (bf16 vs fp16), which may cause small numeric output differences but does not alter control flow or non-CUDA behavior.
> 
> **Overview**
> **Inference dtype selection is now hardware-aware on CUDA.** `load_model` chooses `torch.bfloat16` when `torch.cuda.is_bf16_supported()` and otherwise falls back to `torch.float16`, while leaving MPS/CPU unchanged, to better match the dtype used during training.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c4b37861c785c3a42e52c465f728c204662dc36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->