### PR TITLE
refactor: use sparse_prediction end-to-end

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -710,6 +710,13 @@ def main():
     def compute_metrics(eval_pred):
         predictions, labels = eval_pred  # predictions: (N_masks,), labels: (B, L)
         labels_flat = labels[labels != -100]
+        # Alignment between preds and labels depends on both sides flattening
+        # row-major; if that invariant ever drifts (e.g. a preprocess hook
+        # reshapes labels), accuracy would silently go wrong rather than error.
+        assert predictions.shape == labels_flat.shape, (
+            f"sparse prediction/label shape mismatch: "
+            f"{predictions.shape} vs {labels_flat.shape}"
+        )
         correct = (predictions == labels_flat).sum()
         total = labels_flat.size
         return {"accuracy": float(correct) / max(int(total), 1)}

--- a/training/train.py
+++ b/training/train.py
@@ -625,6 +625,12 @@ def main():
         torch_dtype=torch.bfloat16 if torch.cuda.is_available() else torch.float32,
     )
 
+    # Run the LM head only on mask positions — every training example has
+    # exactly one unmasked label (the answer slot), so the head skips ~250x
+    # non-mask positions (avg prompt length ~150, one mask per prompt).
+    # Inference uses a parallel path via ``prediction_positions`` in model.py.
+    model.sparse_prediction = True
+
     # If we loaded a pristine checkpoint the decoder is still full-vocab; prune
     # it down to the 128 answer-letter rows. When resuming from a previously
     # pruned checkpoint the decoder already has 128 outputs and we skip prune.
@@ -691,17 +697,21 @@ def main():
     if training_examples:
         print_sample_example(training_examples[0])
 
-    # Accuracy on the held-out eval set, measured only at mask positions.
-    # preprocess_logits_for_metrics keeps only the argmax per position so we
-    # don't accumulate (N, L, V) logits across the entire eval set.
+    # Accuracy on the held-out eval set. With ``sparse_prediction``, the model
+    # returns logits of shape (num_masks, answer_vocab) — one row per label
+    # that survived the ``!= -100`` filter. ``preprocess_logits_for_metrics``
+    # collapses those to predicted compact-ids so Trainer doesn't accumulate
+    # per-vocab logits across the eval set. ``compute_metrics`` flattens
+    # labels the same way (row-major over (batch, seq), selecting non-ignored
+    # positions) so predictions and labels line up 1:1.
     def preprocess_logits_for_metrics(logits, labels):
         return logits.argmax(dim=-1)
 
     def compute_metrics(eval_pred):
-        predictions, labels = eval_pred  # predictions already argmax'd
-        mask = labels != -100
-        correct = ((predictions == labels) & mask).sum()
-        total = mask.sum()
+        predictions, labels = eval_pred  # predictions: (N_masks,), labels: (B, L)
+        labels_flat = labels[labels != -100]
+        correct = (predictions == labels_flat).sum()
+        total = labels_flat.size
         return {"accuracy": float(correct) / max(int(total), 1)}
 
     # When eval is enabled we save at the same cadence so

--- a/wsd/masked_language_model.py
+++ b/wsd/masked_language_model.py
@@ -76,20 +76,21 @@ def unmask_token(text: str) -> UnmaskResult:
     components = load_model()
 
     inputs = components.tokenizer(text, return_tensors="pt").to(components.device)
-    mask_idx = (inputs.input_ids == components.tokenizer.mask_token_id).nonzero()
-
-    if len(mask_idx) == 0:
-        raise PromptMaskError()
+    positions = _prediction_positions(
+        inputs.input_ids, components.tokenizer.mask_token_id,
+    )
 
     with torch.no_grad():
-        outputs = components.model(**inputs)
+        outputs = components.model(**inputs, prediction_positions=positions)
 
-    logits = outputs.logits[0, mask_idx[0, 1]]
-    probs = torch.softmax(logits, dim=-1)
+    # With prediction_positions the model gathers one row per example, so
+    # logits is shape (batch, answer_vocab); single prompt → one row.
+    probs = torch.softmax(outputs.logits[0], dim=-1)
     compact_id = int(torch.argmax(probs).item())
 
-    decoded_token = components.letter_set.letters[compact_id]
-    return UnmaskResult(token=decoded_token, probabilities=probs)
+    return UnmaskResult(
+        token=components.letter_set.letters[compact_id], probabilities=probs,
+    )
 
 
 # Sub-batch size used when length-bucketing inside ``unmask_token_batch``.
@@ -163,80 +164,79 @@ def unmask_token_batch(texts: list[str]) -> list[UnmaskResult]:
     return cast(list[UnmaskResult], results)
 
 
+def _prediction_positions(input_ids: torch.Tensor, mask_token_id: int) -> torch.Tensor:
+    """LongTensor ``(batch,)`` column index of the single answer position per row.
+
+    Each WSD prompt contains exactly one ``[MASK]``; we return integer positions
+    (not a boolean mask) so the model can gather rows via indexed select. Bool
+    ``masked_select`` would force the GPU to report ``mask.sum()`` back to the
+    host before sizing its output — a sync that drains the stream and serializes
+    the multi-chunk dispatch in ``_unmask_chunks_cuda_parallel``.
+    """
+    is_mask = input_ids == mask_token_id
+    per_row = is_mask.sum(dim=1)
+    if bool((per_row != 1).any()):
+        raise PromptMaskError()
+    return is_mask.int().argmax(dim=1)
+
+
+def _logits_to_results(
+    logits: torch.Tensor, letters: tuple[str, ...],
+) -> list[UnmaskResult]:
+    """Turn ``(batch, answer_vocab)`` logits into per-example UnmaskResults."""
+    probs = torch.softmax(logits, dim=-1)
+    compact_ids = torch.argmax(probs, dim=-1).tolist()
+    return [
+        UnmaskResult(token=letters[cid], probabilities=p)
+        for cid, p in zip(compact_ids, probs, strict=True)
+    ]
+
+
 def _unmask_chunks_cuda_parallel(
     chunks: list[tuple[list[int], list[str]]],
     components: ModelComponents,
 ) -> list[list[UnmaskResult]]:
     """Dispatch each chunk's forward pass on its own CUDA stream.
 
-    Tokenization and mask-position lookup run on CPU before we enter the
-    stream context. Doing the lookup on-GPU would require a ``.item()``
-    sync that waits for the chunk's own stream to drain, which serialized
-    the per-chunk dispatch with the host and erased most of the stream
-    parallelism. On CPU the lookup is ~microseconds per chunk.
+    Tokenization and mask validation run on CPU before we enter the stream
+    context so the per-chunk dispatch can overlap — on-GPU validation would
+    force a ``.item()`` sync that drains the stream and erases the parallelism.
     """
     mask_id = components.tokenizer.mask_token_id
     streams = [torch.cuda.Stream() for _ in chunks]
-    pending: list[tuple[list[tuple[torch.Tensor, int]], torch.cuda.Stream]] = []
+    pending: list[tuple[torch.Tensor, torch.cuda.Stream]] = []
 
     for (_, chunk_texts), stream in zip(chunks, streams, strict=True):
         cpu_inputs = components.tokenizer(
             chunk_texts, return_tensors="pt", padding=True,
         )
-        mask_positions: list[tuple[int, int]] = []
-        for i in range(len(chunk_texts)):
-            positions = (cpu_inputs.input_ids[i] == mask_id).nonzero(as_tuple=True)[0]
-            if positions.numel() == 0:
-                raise PromptMaskError()
-            mask_positions.append((i, int(positions[0])))
+        positions_cpu = _prediction_positions(cpu_inputs.input_ids, mask_id)
 
         with torch.cuda.stream(stream), torch.no_grad():
             inputs = cpu_inputs.to(components.device, non_blocking=True)
-            outputs = components.model(**inputs)
-            logits_per_example = [
-                (outputs.logits[bi, si], bi) for bi, si in mask_positions
-            ]
-        pending.append((logits_per_example, stream))
+            positions = positions_cpu.to(components.device, non_blocking=True)
+            outputs = components.model(**inputs, prediction_positions=positions)
+        pending.append((outputs.logits, stream))
 
+    letters = components.letter_set.letters
     results: list[list[UnmaskResult]] = []
-    for logits_per_example, stream in pending:
+    for logits, stream in pending:
         stream.synchronize()
-        chunk_out: list[UnmaskResult] = []
-        for logits, _ in logits_per_example:
-            probs = torch.softmax(logits, dim=-1)
-            compact_id = int(torch.argmax(probs).item())
-            decoded = components.letter_set.letters[compact_id]
-            chunk_out.append(UnmaskResult(token=decoded, probabilities=probs))
-        results.append(chunk_out)
+        results.append(_logits_to_results(logits, letters))
     return results
 
 
 def _unmask_chunk(texts: list[str], components: ModelComponents) -> list[UnmaskResult]:
     """Single forward pass for a length-homogeneous chunk."""
-    # Tokenize all texts with padding
     inputs = components.tokenizer(texts, return_tensors="pt", padding=True).to(components.device)
+    positions = _prediction_positions(
+        inputs.input_ids, components.tokenizer.mask_token_id,
+    )
 
-    # Find mask token positions for each example in the batch
-    mask_positions = []
-    for i in range(len(texts)):
-        mask_idx = (inputs.input_ids[i] == components.tokenizer.mask_token_id).nonzero()
-        if len(mask_idx) == 0:
-            raise PromptMaskError()
-        mask_positions.append((i, mask_idx[0, 0].item()))
-
-    # Run batched forward pass
     with torch.no_grad():
-        outputs = components.model(**inputs)
+        outputs = components.model(**inputs, prediction_positions=positions)
 
-    # Extract predictions for each mask token
-    results = []
-    for batch_idx, seq_idx in mask_positions:
-        logits = outputs.logits[batch_idx, seq_idx]
-        probs = torch.softmax(logits, dim=-1)
-        compact_id = int(torch.argmax(probs).item())
-        decoded_token = components.letter_set.letters[compact_id]
-        results.append(UnmaskResult(token=decoded_token, probabilities=probs))
-    return results
+    return _logits_to_results(outputs.logits, components.letter_set.letters)
 
 
 def main():

--- a/wsd/masked_language_model.py
+++ b/wsd/masked_language_model.py
@@ -74,23 +74,7 @@ def load_model(model_name: str = _DEFAULT_MODEL) -> ModelComponents:
 
 def unmask_token(text: str) -> UnmaskResult:
     components = load_model()
-
-    inputs = components.tokenizer(text, return_tensors="pt").to(components.device)
-    positions = _prediction_positions(
-        inputs.input_ids, components.tokenizer.mask_token_id,
-    )
-
-    with torch.no_grad():
-        outputs = components.model(**inputs, prediction_positions=positions)
-
-    # With prediction_positions the model gathers one row per example, so
-    # logits is shape (batch, answer_vocab); single prompt → one row.
-    probs = torch.softmax(outputs.logits[0], dim=-1)
-    compact_id = int(torch.argmax(probs).item())
-
-    return UnmaskResult(
-        token=components.letter_set.letters[compact_id], probabilities=probs,
-    )
+    return _unmask_chunk([text], components)[0]
 
 
 # Sub-batch size used when length-bucketing inside ``unmask_token_batch``.
@@ -228,11 +212,15 @@ def _unmask_chunks_cuda_parallel(
 
 def _unmask_chunk(texts: list[str], components: ModelComponents) -> list[UnmaskResult]:
     """Single forward pass for a length-homogeneous chunk."""
-    inputs = components.tokenizer(texts, return_tensors="pt", padding=True).to(components.device)
-    positions = _prediction_positions(
-        inputs.input_ids, components.tokenizer.mask_token_id,
+    # Compute mask positions on the CPU tensor before moving to device so the
+    # validation sum/any doesn't force a device→host sync.
+    cpu_inputs = components.tokenizer(texts, return_tensors="pt", padding=True)
+    positions_cpu = _prediction_positions(
+        cpu_inputs.input_ids, components.tokenizer.mask_token_id,
     )
 
+    inputs = cpu_inputs.to(components.device)
+    positions = positions_cpu.to(components.device)
     with torch.no_grad():
         outputs = components.model(**inputs, prediction_positions=positions)
 

--- a/wsd/masked_language_model.py
+++ b/wsd/masked_language_model.py
@@ -165,17 +165,17 @@ def unmask_token_batch(texts: list[str]) -> list[UnmaskResult]:
 
 
 def _prediction_positions(input_ids: torch.Tensor, mask_token_id: int) -> torch.Tensor:
-    """LongTensor ``(batch,)`` column index of the single answer position per row.
+    """LongTensor ``(batch,)`` column index of the first ``[MASK]`` per row.
 
-    Each WSD prompt contains exactly one ``[MASK]``; we return integer positions
-    (not a boolean mask) so the model can gather rows via indexed select. Bool
-    ``masked_select`` would force the GPU to report ``mask.sum()`` back to the
-    host before sizing its output — a sync that drains the stream and serializes
-    the multi-chunk dispatch in ``_unmask_chunks_cuda_parallel``.
+    Returned as integer positions (not a boolean mask) so the model can gather
+    rows via indexed select. A bool ``masked_select`` would force the GPU to
+    report ``mask.sum()`` back to the host before sizing its output — a sync
+    that drains the stream and serializes the multi-chunk dispatch in
+    ``_unmask_chunks_cuda_parallel``. Rows with multiple masks use the first
+    (argmax returns the first max); rows with no mask raise.
     """
     is_mask = input_ids == mask_token_id
-    per_row = is_mask.sum(dim=1)
-    if bool((per_row != 1).any()):
+    if bool((is_mask.sum(dim=1) == 0).any()):
         raise PromptMaskError()
     return is_mask.int().argmax(dim=1)
 

--- a/wsd/model.py
+++ b/wsd/model.py
@@ -27,6 +27,13 @@ def _answer_vocab_size(config: ModernBertConfig) -> int:
     return int(getattr(config, "answer_vocab_size", config.vocab_size))
 
 
+class MutuallyExclusivePredictionArgsError(ValueError):
+    def __init__(self):
+        super().__init__(
+            "prediction_positions and labels are mutually exclusive",
+        )
+
+
 class WSDModernBertForMaskedLM(ModernBertForMaskedLM):
     """ModernBertForMaskedLM with a compact answer-only decoder."""
 
@@ -77,9 +84,7 @@ class WSDModernBertForMaskedLM(ModernBertForMaskedLM):
                 # Would produce a (batch, answer_vocab) logits tensor against a
                 # (B, L) labels tensor — the shape error from loss_function is
                 # inscrutable, so surface the misuse at the branch point.
-                raise ValueError(
-                    "prediction_positions and labels are mutually exclusive",
-                )
+                raise MutuallyExclusivePredictionArgsError()
             batch_idx = torch.arange(
                 last_hidden_state.size(0), device=last_hidden_state.device,
             )

--- a/wsd/model.py
+++ b/wsd/model.py
@@ -14,6 +14,7 @@ Config fields consumed
   (otherwise HF will try to re-tie the compact decoder to the full embeddings
   and fail).
 """
+import torch
 from torch import nn
 from transformers.modeling_outputs import MaskedLMOutput
 from transformers.models.modernbert.modeling_modernbert import (
@@ -49,6 +50,7 @@ class WSDModernBertForMaskedLM(ModernBertForMaskedLM):
         position_ids=None,
         inputs_embeds=None,
         labels=None,
+        prediction_positions=None,
         **kwargs,
     ):
         outputs = self.model(
@@ -60,7 +62,22 @@ class WSDModernBertForMaskedLM(ModernBertForMaskedLM):
         )
         last_hidden_state = outputs[0]
 
-        if self.sparse_prediction and labels is not None:
+        # Two sparse paths feed the same compact decoder:
+        # - ``prediction_positions`` (LongTensor, shape ``(batch,)``): inference
+        #   path. One answer column per row — we gather those rows via indexed
+        #   select so the output shape is statically ``(batch, hidden)``. A
+        #   boolean mask here would force ``masked_select`` to read ``mask.sum()``
+        #   from the GPU to size its output, draining the CUDA stream and
+        #   serializing the per-chunk dispatch in ``_unmask_chunks_cuda_parallel``.
+        # - ``self.sparse_prediction`` + labels: training/eval path. Mirrors the
+        #   stock ModernBERT behavior of filtering out ``sparse_pred_ignore_index``
+        #   positions before the head, saving head compute on non-mask tokens.
+        if prediction_positions is not None:
+            batch_idx = torch.arange(
+                last_hidden_state.size(0), device=last_hidden_state.device,
+            )
+            last_hidden_state = last_hidden_state[batch_idx, prediction_positions]
+        elif self.sparse_prediction and labels is not None:
             labels = labels.view(-1)
             last_hidden_state = last_hidden_state.view(labels.shape[0], -1)
             mask_tokens = labels != self.sparse_pred_ignore_index

--- a/wsd/model.py
+++ b/wsd/model.py
@@ -73,6 +73,13 @@ class WSDModernBertForMaskedLM(ModernBertForMaskedLM):
         #   stock ModernBERT behavior of filtering out ``sparse_pred_ignore_index``
         #   positions before the head, saving head compute on non-mask tokens.
         if prediction_positions is not None:
+            if labels is not None:
+                # Would produce a (batch, answer_vocab) logits tensor against a
+                # (B, L) labels tensor — the shape error from loss_function is
+                # inscrutable, so surface the misuse at the branch point.
+                raise ValueError(
+                    "prediction_positions and labels are mutually exclusive",
+                )
             batch_idx = torch.arange(
                 last_hidden_state.size(0), device=last_hidden_state.device,
             )


### PR DESCRIPTION
## Summary
- Stop manually re-implementing sparse prediction in inference. The LM head was running over the full ``(batch, seq, hidden)`` and we sliced out one row per example — wasted decoder compute on every non-mask position.
- ``WSDModernBertForMaskedLM.forward`` now accepts ``prediction_positions`` (``LongTensor`` shape ``(batch,)``). When given, it gathers one hidden row per example via indexed select before the head: statically-known ``(batch, hidden)`` output, no device→host sync.
- Training sets ``model.sparse_prediction = True`` so the trainer's labels-based sparse path runs the head only on answer positions too.

## Why integer positions, not a boolean mask
A boolean ``prediction_mask`` forces ``masked_select`` to read ``mask.sum()`` off the GPU before it can size its output. That sync drained the per-chunk CUDA stream in ``_unmask_chunks_cuda_parallel`` and serialized the multi-stream dispatch — measured 16% regression vs main. Integer positions sidestep the sync.

## Benchmark (GB10, ``bench_sparse.py``, N=512, BS=32)
| branch | accuracy | throughput |
|---|---|---|
| ``main`` | 0.7480 | 258.8 ex/s |
| this branch | 0.7500 | 261.4 ex/s |

Accuracy delta (+1 / 512) is within noise; throughput matches main.

## Test plan
- [x] ``bench_sparse.py`` confirms accuracy flat and throughput not regressed on GB10.
- [ ] Next training run validates the ``sparse_prediction`` + new ``compute_metrics`` path end-to-end (the existing ``compute_metrics`` was rewritten to handle the new ``(N_masks,)`` prediction shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model forward semantics and evaluation metric computation to rely on sparse logits/flattened labels, which could silently skew accuracy or inference outputs if alignment assumptions break.
> 
> **Overview**
> Enables end-to-end *sparse prediction* so the LM head/decoder run only on the masked answer position instead of the full sequence.
> 
> `WSDModernBertForMaskedLM.forward` now accepts `prediction_positions` for inference-time gathering (and errors if combined with `labels`), while `training/train.py` turns on `model.sparse_prediction` and updates eval accuracy to compare `(N_masks,)` predictions against flattened non-`-100` labels with an alignment assert.
> 
> Inference in `masked_language_model.py` is refactored to use the model’s new `prediction_positions` path (including CUDA-streamed batching), centralizing mask-position detection and result decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf21c29b5be90c02b45eea7d97fdb166c1f214f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Optimized model training and evaluation through sparse prediction mode for improved computational efficiency
* Updated evaluation metrics alignment for accurate measurement of model performance
* Streamlined mask token handling and position computation during inference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->