### PR TITLE
fix(benchmark): handle empty corpus and harden zip invariants

### DIFF
--- a/wsd/benchmark.py
+++ b/wsd/benchmark.py
@@ -70,6 +70,10 @@ if __name__ == "__main__":
     # Process examples in batches
     num_batches = (len(examples) + batch_size - 1) // batch_size
 
+    # Pre-initialize so the final print doesn't NameError on an empty corpus
+    # (where num_batches == 0 and the loop body never runs).
+    accuracy = 0.0
+
     with tqdm(total=len(examples), desc="Evaluating examples") as pbar:
         for batch_idx in range(num_batches):
             start_idx = batch_idx * batch_size
@@ -87,14 +91,14 @@ if __name__ == "__main__":
                     marked_sentence=example.marked_text,
                     definitions=definitions
                 )
-                for example, definitions in zip(batch, all_definitions, strict=False)
+                for example, definitions in zip(batch, all_definitions, strict=True)
             ]
 
             # Process entire batch at once
             predictions = disambiguate_word_batch(batch_data)
 
             # Check predictions and update accuracy
-            for i, (example, result) in enumerate(zip(batch, predictions, strict=False)):
+            for i, (example, result) in enumerate(zip(batch, predictions, strict=True)):
                 is_correct = result.synset_id == example.synset_id
                 if is_correct:
                     correct += 1


### PR DESCRIPTION
## Summary
- Pre-initialize `accuracy = 0.0` so the final print doesn't `NameError` when `examples` is empty (`num_batches == 0` ⇒ loop body never runs)
- Switch two `zip()` calls in the batch loop from `strict=False` to `strict=True` — a length mismatch between `batch`/`all_definitions` or `batch`/`predictions` should surface as a loud failure rather than silently truncating results

## Test plan
- [x] `ruff check wsd/benchmark.py`
- [ ] Local smoke run on a small corpus to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the benchmarking script, adding a safe default for `accuracy` and making length mismatches raise immediately rather than silently truncating results.
> 
> **Overview**
> Pre-initializes `accuracy` in `wsd/benchmark.py` so running the benchmark on an empty example set doesn’t crash at the final print.
> 
> Hardens batching by switching the `zip()`s that pair `batch` with `all_definitions` and `predictions` to `strict=True`, surfacing any length mismatches as errors instead of silently dropping items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523589c8e955eed1240e42d06085749b5c9fb3f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->