### PR TITLE
refactor(wsd): flatten disambiguate_word_batch result assembly

### DIFF
--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -297,51 +297,33 @@ def disambiguate_word_batch(
 
     components = load_model()
 
-    # Prepare prompts and track which ones are valid
-    prompts = []
-    valid_indices = []  # Track which inputs have definitions
-    for i, input_obj in enumerate(batch_data):
-        if input_obj.definitions:
-            text = create_multiple_choice_prompt(
-                input_obj.word,
-                components.tokenizer.mask_token,
-                input_obj.marked_sentence,
-                input_obj.definitions,
-                components.tokenizer,
-                start_offset=start_offset,
-            )
-            prompts.append(text)
-            valid_indices.append(i)
+    # Build prompts only for inputs with definitions. Inputs without definitions
+    # get a fixed NO_DEFINITIONS_FOUND result without touching the model.
+    results: list[DisambiguationResult] = [
+        DisambiguationResult(synset_id=NO_DEFINITIONS_FOUND, definition="", confidence=0.0)
+        for _ in batch_data
+    ]
+    valid = [(i, inp) for i, inp in enumerate(batch_data) if inp.definitions]
+    if not valid:
+        return results
 
-    # If no valid prompts, return empty results for all
-    if not prompts:
-        return [
-            DisambiguationResult(
-                synset_id=NO_DEFINITIONS_FOUND,
-                definition="",
-                confidence=0.0
-            )
-            for _ in batch_data
-        ]
-
-    # Get predictions for all prompts in batch
+    prompts = [
+        create_multiple_choice_prompt(
+            inp.word,
+            components.tokenizer.mask_token,
+            inp.marked_sentence,
+            inp.definitions,
+            components.tokenizer,
+            start_offset=start_offset,
+        )
+        for _, inp in valid
+    ]
     batch_results = unmask_token_batch(prompts)
 
-    # Process results
-    valid_set = set(valid_indices)
-    results = []
-    result_idx = 0
-    for i, input_obj in enumerate(batch_data):
-        if i not in valid_set:
-            results.append(DisambiguationResult(
-                synset_id=NO_DEFINITIONS_FOUND, definition="", confidence=0.0,
-            ))
-            continue
-        unmask_result = batch_results[result_idx]
-        result_idx += 1
-        results.append(_result_from_probs(
-            unmask_result.probabilities, input_obj.definitions, start_offset=start_offset,
-        ))
+    for (i, inp), unmask_result in zip(valid, batch_results, strict=True):
+        results[i] = _result_from_probs(
+            unmask_result.probabilities, inp.definitions, start_offset=start_offset,
+        )
     return results
 
 


### PR DESCRIPTION
## Summary
- Drop the `valid_indices` / `valid_set` / `result_idx` bookkeeping in `disambiguate_word_batch`
- Pre-fill `results` with `NO_DEFINITIONS_FOUND` placeholders, collect `valid = [(i, inp) …]` once, dispatch prompts for the valid subset, then overwrite by index via a single `zip(valid, batch_results, strict=True)`
- Net −18 lines; same behavior; the "which output came from which input" mapping now lives in one loop rather than being split across a set-membership check and an incrementing counter

## Test plan
- [x] `ruff check wsd/word_sense_disambiguation.py`
- [ ] CI: `test_disambiguate_word_batch_{empty,no_definitions,with_definitions,mixed}` exercise the three code paths (empty batch, all invalid, mixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `disambiguate_word_batch`, but it changes how batch outputs are mapped back to inputs; mistakes would surface as misaligned disambiguation results or incorrect `NO_DEFINITIONS_FOUND` placeholders.
> 
> **Overview**
> Refactors `disambiguate_word_batch` to pre-fill outputs with `NO_DEFINITIONS_FOUND`, build prompts only for inputs that have definitions, and then overwrite results in-place by index.
> 
> This removes the prior `valid_indices`/`result_idx` bookkeeping and replaces it with a single `zip(..., strict=True)` loop to keep model outputs aligned with their originating inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9cad0bc84352bb6401ab231e541a23cb3982359. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->