### PR TITLE
cleanup: drop dead get_definitions_single helper

### DIFF
--- a/wsd/test_word_sense_disambiguation.py
+++ b/wsd/test_word_sense_disambiguation.py
@@ -17,7 +17,6 @@ from wsd.word_sense_disambiguation import (
     disambiguate_word_batch,
     get_choice_probabilities,
     get_definitions,
-    get_definitions_single,
 )
 
 
@@ -118,27 +117,6 @@ def test_get_definitions_api_error():
         # Should return empty list for failed query
         assert len(results) == 1
         assert results[0] == []
-
-
-def test_get_definitions_single():
-    """Test get_definitions_single convenience function"""
-    with requests_mock.Mocker() as m:
-        url = f"{WORDNET_URL}/lexicons/omw-en:1.4/definitions"
-        mock_response = {
-            "data": [
-                {
-                    "definitions": {
-                        "omw-en-1234-n": "a financial institution"
-                    }
-                }
-            ]
-        }
-        m.post(url, json=mock_response)
-
-        results = get_definitions_single("bank", "n")
-
-        assert len(results) == 1
-        assert results[0].synset_id == "omw-en-1234-n"
 
 
 def test_create_marked_sentence(monkeypatch):

--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -204,23 +204,6 @@ def get_definitions(queries: list[WordQuery], language: str = "en") -> list[list
     return results
 
 
-def get_definitions_single(word: str, pos: str, language: str = "en") -> list[Definition]:
-    """
-    Convenience function to fetch definitions for a single word.
-
-    Args:
-        word: Word form to look up
-        pos: Part of speech
-        language: Language code (default: "en")
-
-    Returns:
-        List of Definition objects for the word
-    """
-    query = WordQuery(form=word, pos=pos)
-    results = get_definitions([query], language)
-    return results[0] if results else []
-
-
 def get_choice_probabilities(
     probs, definitions: list[Definition], start_offset: int = 0,
 ) -> list[float]:


### PR DESCRIPTION
## Summary
- Remove `get_definitions_single()` from `wsd/word_sense_disambiguation.py` — a thin `get_definitions([WordQuery(...)])[0]` wrapper with no callers outside its own unit test
- Remove the corresponding `test_get_definitions_single` in `wsd/test_word_sense_disambiguation.py`
- Net −39 lines

## Test plan
- [x] `ruff check wsd/`
- [x] `grep get_definitions_single wsd/ training/ -r` confirms no remaining references
- [ ] CI to run the remaining `get_definitions` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this deletes a thin helper with no remaining callers and only updates tests accordingly.
> 
> **Overview**
> Drops the dead `get_definitions_single()` wrapper from `wsd/word_sense_disambiguation.py` and removes its dedicated unit test in `wsd/test_word_sense_disambiguation.py`.
> 
> No functional behavior changes beyond eliminating the unused helper; definition lookups continue to go through `get_definitions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6298fb0b1ec6fe148c37cbe2f1d0aa796f39e06e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->