### PR TITLE
refactor: share wn lexicon + definition lookup across callers

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -26,6 +26,7 @@ from transformers import (
 
 from training.wn_data import WordNetExample
 from training.wn_data import split as split_wn_examples
+from wsd.benchmark import fetch_synset_definitions, load_wn_english
 from wsd.letters import NOTA_LETTER_INDEX, LetterSet, build_letters
 from wsd.model import WSDModernBertForMaskedLM
 from wsd.model_surgery import prune_decoder
@@ -280,29 +281,13 @@ def build_eval_examples_from_wn(
     (can happen when the wn lexicon disagrees with the example's own synset
     metadata), and any where we'd exceed the letter budget.
     """
-    import wn as _wn
-
-    try:
-        en = _wn.Wordnet(lexicon="omw-en:1.4")
-    except _wn.Error:
-        _wn.download("omw-en:1.4")
-        en = _wn.Wordnet(lexicon="omw-en:1.4")
-
-    pos_a_and_s = {"a", "s"}
+    en = load_wn_english()
     letters = build_letters(tokenizer).letters
     max_definitions = len(letters) - 1  # last letter reserved for "none of the above"
 
     out: list[TrainingExample] = []
     for ex in wn_examples:
-        pos_options = pos_a_and_s if ex.pos == "a" else {ex.pos}
-        defs: dict[str, str] = {}
-        for word in en.words(form=ex.lemma):
-            for synset in word.synsets():
-                if synset.pos not in pos_options:
-                    continue
-                text = synset.definition()
-                if text:
-                    defs[synset.id] = text
+        defs = fetch_synset_definitions(en, ex.lemma, ex.pos)
         if ex.synset_id not in defs:
             continue
         if len(defs) > max_definitions:

--- a/wsd/benchmark.py
+++ b/wsd/benchmark.py
@@ -23,6 +23,36 @@ class WordNetExample:
     sentence: str  # original, unmarked example
 
 
+def load_wn_english() -> wn.Wordnet:
+    """Load (downloading on first use) the omw-en:1.4 WordNet lexicon."""
+    try:
+        return wn.Wordnet(lexicon="omw-en:1.4")
+    except wn.Error:
+        wn.download("omw-en:1.4")
+        return wn.Wordnet(lexicon="omw-en:1.4")
+
+
+def fetch_synset_definitions(en: wn.Wordnet, lemma: str, pos: str) -> dict[str, str]:
+    """Return ``{synset_id: definition_text}`` for ``(lemma, pos)``.
+
+    For ``pos="a"`` both "a" (adjective) and "s" (satellite adjective) synsets
+    are included — this matches the adjective expansion that
+    :func:`wsd.word_sense_disambiguation.get_definitions` does at inference
+    time, so training-time eval and bias probing see the same option set the
+    deployed pipeline would.
+    """
+    pos_options = {"a", "s"} if pos == "a" else {pos}
+    defs: dict[str, str] = {}
+    for word in en.words(form=lemma):
+        for synset in word.synsets():
+            if synset.pos not in pos_options:
+                continue
+            text = synset.definition()
+            if text:
+                defs[synset.id] = text
+    return defs
+
+
 def collect_wordnet_examples():
     """Yield every usable (synset, word form, example) tuple from OMW English.
 
@@ -30,13 +60,7 @@ def collect_wordnet_examples():
     the form can't be marked with clean word boundaries.
     """
 
-    # Ensure omw-en:1.4 is downloaded
-    try:
-        en = wn.Wordnet(lexicon="omw-en:1.4")
-    except wn.Error:
-        print("Downloading omw-en:1.4...")
-        wn.download("omw-en:1.4")
-        en = wn.Wordnet(lexicon="omw-en:1.4")
+    en = load_wn_english()
 
     # Iterate through all synsets
     for synset in en.synsets():

--- a/wsd/bias_probe.py
+++ b/wsd/bias_probe.py
@@ -30,10 +30,14 @@ import argparse
 import random
 from dataclasses import dataclass
 
-import wn
 from tqdm import tqdm
 
-from wsd.benchmark import WordNetExample, collect_wordnet_examples
+from wsd.benchmark import (
+    WordNetExample,
+    collect_wordnet_examples,
+    fetch_synset_definitions,
+    load_wn_english,
+)
 from wsd.letters import NOTA_LETTER_INDEX
 from wsd.prompt import Definition
 from wsd.word_sense_disambiguation import (
@@ -55,43 +59,16 @@ class OffsetResult:
         return self.n_correct / self.n_evaluated if self.n_evaluated else 0.0
 
 
-def _load_wn():
-    """Load or download the omw-en:1.4 lexicon."""
-    try:
-        return wn.Wordnet(lexicon="omw-en:1.4")
-    except wn.Error:
-        wn.download("omw-en:1.4")
-        return wn.Wordnet(lexicon="omw-en:1.4")
-
-
-def _fetch_definitions_for_example(
-    en: wn.Wordnet, ex: WordNetExample,
-) -> list[Definition] | None:
-    """Mirror build_eval_examples_from_wn's lookup: fetch defs for (lemma, pos).
-
-    Returns None when the example's own synset isn't in the wn lookup (can
-    happen when the lexicon disagrees with the example's metadata), or when
-    there are no definitions at all.
-    """
-    pos_options = {"a", "s"} if ex.pos == "a" else {ex.pos}
-    defs: dict[str, str] = {}
-    for word in en.words(form=ex.lemma):
-        for synset in word.synsets():
-            if synset.pos not in pos_options:
-                continue
-            text = synset.definition()
-            if text:
-                defs[synset.id] = text
-    if ex.synset_id not in defs:
-        return None
-    return [Definition(synset_id=sid, definition=text) for sid, text in defs.items()]
-
-
 def _sample_examples_with_defs(
     n_examples: int, seed: int,
 ) -> tuple[list[WordNetExample], list[list[Definition]]]:
-    """Sample ``n_examples`` and fetch their definitions once (reused across offsets)."""
-    en = _load_wn()
+    """Sample ``n_examples`` and fetch their definitions once (reused across offsets).
+
+    Skips examples whose own ``synset_id`` isn't in the wn lookup — that happens
+    when the lexicon disagrees with the example's metadata and we'd have no
+    correct answer to compare against.
+    """
+    en = load_wn_english()
 
     all_examples = list(collect_wordnet_examples())
     rng = random.Random(seed)
@@ -100,11 +77,13 @@ def _sample_examples_with_defs(
     out_ex: list[WordNetExample] = []
     out_defs: list[list[Definition]] = []
     for ex in all_examples:
-        defs = _fetch_definitions_for_example(en, ex)
-        if defs is None:
+        defs = fetch_synset_definitions(en, ex.lemma, ex.pos)
+        if ex.synset_id not in defs:
             continue
         out_ex.append(ex)
-        out_defs.append(defs)
+        out_defs.append(
+            [Definition(synset_id=sid, definition=text) for sid, text in defs.items()],
+        )
         if len(out_ex) >= n_examples:
             break
     return out_ex, out_defs


### PR DESCRIPTION
## Summary
- Extract `load_wn_english()` and `fetch_synset_definitions(en, lemma, pos)` into `wsd/benchmark.py` (already the natural home — `collect_wordnet_examples()` lives there and both callers already imported from it)
- `wsd/bias_probe.py` and `training/train.py:build_eval_examples_from_wn` previously reimplemented the same open-with-download fallback and the same (lemma, pos) → `{synset_id: definition}` loop (including the `"a"` → `{"a", "s"}` adjective expansion). The two copies had already started drifting — one annotated `wn.Wordnet` as a type, the other imported `wn` only for the `Error` class.
- Drop the now-unused `import wn` from `bias_probe.py`

## Test plan
- [x] `ruff check wsd/benchmark.py wsd/bias_probe.py training/train.py`
- [ ] CI: existing eval+benchmark paths cover `load_wn_english` and `fetch_synset_definitions` transitively
- [ ] Local smoke: `python -m wsd.bias_probe --n-examples 10 --offsets 0 5` (requires a preloaded model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the shared definition/lexicon lookup path used by training-time evaluation and bias probing, which could alter which examples/options are included if the helper behavior differs from the previous inlined logic.
> 
> **Overview**
> **Refactors WordNet access to a single shared implementation.** Adds `load_wn_english()` (download-on-first-use) and `fetch_synset_definitions()` to `wsd/benchmark.py`, including the adjective `"a"`→`{"a","s"}` expansion.
> 
> Updates `training/train.py` (`build_eval_examples_from_wn`) and `wsd/bias_probe.py` to call these helpers instead of maintaining their own `wn` download + synset-definition loops, and removes the now-unneeded direct `wn` import/loader code in `bias_probe.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e46f1d351fb805d282002fd04d015cbfcb9027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->