### PR TITLE
refactor(training): simplify create_examples_for_synset shuffle

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -105,31 +105,21 @@ def create_examples_for_synset(
     synset_id = synset["id"]
     synset_pos = synset["pos"]
 
-    # Collect definitions only from synsets with the same POS tag
-    pos_definitions = []
-    synset_to_definition = {}
-
-    for other_synset in all_synsets:
-        if other_synset["pos"] != synset_pos:
-            continue
-
-        other_synset_id = other_synset["id"]
-
-        # Randomly pick either source or alternative definition
-        chosen_def = random.choice([
-            other_synset["source_definition"],
-            other_synset["alternative_definition"]
-        ])
-
-        def_idx = len(pos_definitions)
-        pos_definitions.append(Definition(synset_id=other_synset_id, definition=chosen_def))
-        synset_to_definition[other_synset_id] = def_idx
-
-    # Shuffle definitions for variety
-    indices = list(range(len(pos_definitions)))
-    random.shuffle(indices)
-    shuffled_definitions = [pos_definitions[i] for i in indices]
-    index_mapping = {old_idx: new_idx for new_idx, old_idx in enumerate(indices)}
+    # Build one Definition per same-POS synset, picking a source or alternative
+    # definition uniformly; then shuffle in place and locate the correct slot
+    # by synset_id. Locating after the shuffle drops the parallel
+    # synset_to_definition / index_mapping dicts the old version carried.
+    shuffled_definitions = [
+        Definition(
+            synset_id=s["id"],
+            definition=random.choice([s["source_definition"], s["alternative_definition"]]),
+        )
+        for s in all_synsets if s["pos"] == synset_pos
+    ]
+    random.shuffle(shuffled_definitions)
+    correct_shuffled_idx = next(
+        i for i, d in enumerate(shuffled_definitions) if d.synset_id == synset_id
+    )
 
     # Create one example for each sentence
     letters = build_letters(tokenizer).letters
@@ -148,10 +138,6 @@ def create_examples_for_synset(
             continue
 
         start_offset = random.randint(0, max_offset) if max_offset > 0 else 0
-
-        # Find correct answer after shuffling
-        correct_original_idx = synset_to_definition[synset_id]
-        correct_shuffled_idx = index_mapping[correct_original_idx]
         correct_letter = letters[start_offset + correct_shuffled_idx]
 
         prompt = create_multiple_choice_prompt(


### PR DESCRIPTION
## Summary
- Collapse the `pos_definitions` + `synset_to_definition` (synset_id → pre-shuffle index) + `indices` + `index_mapping` (old_idx → new_idx) dance in `create_examples_for_synset` down to a single list comprehension + in-place shuffle + one `next()` scan for the correct slot
- Two dict allocations and a pre-shuffle index table removed. `correct_shuffled_idx` is computed once before the sentence loop instead of dereferenced through two lookups per sentence
- Same RNG draws (one `random.choice` per same-POS synset, one shuffle, one `random.randint` per sentence), so training outputs are bit-identical given the same seed. Net −14 lines

## Test plan
- [x] `ruff check training/train.py`
- [ ] Smoke: `python training/train.py --max-steps 5` to confirm dataset build works and the sampled example printed by `print_sample_example` still has a plausible correct-answer letter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to training-data example construction; main behavioral risk is accidentally changing which definition/answer letter is treated as correct after shuffling.
> 
> **Overview**
> Simplifies `create_examples_for_synset` in `training/train.py` by replacing the pre-shuffle index bookkeeping (`synset_to_definition`/`index_mapping`) with a single same-POS `Definition` list, an in-place shuffle, and a one-time scan to find the correct shuffled index.
> 
> This reduces per-sentence overhead by computing `correct_shuffled_idx` once per synset and removes intermediate dict/list allocations while keeping the multiple-choice prompt generation flow unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1598e3eed19e3673464cac5f936b1318c6647ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->