### PR TITLE
cleanup: drop dead start_offset from inference side

### DIFF
--- a/wsd/prompt.py
+++ b/wsd/prompt.py
@@ -85,8 +85,9 @@ def create_multiple_choice_prompt(word: str,
 
     ``definitions[i]`` is rendered with letter ``start_offset + i``; the
     default ``start_offset=0`` keeps the historical "A, B, C, ..." layout.
-    Non-zero offsets are used by the bias probe to test whether the model
-    depends on the specific A-first mapping it saw during training.
+    Training randomizes ``start_offset`` per example so the correct answer is
+    spread across the whole letter range instead of clustering near A;
+    inference always passes 0.
 
     The last letter (index :data:`wsd.letters.NOTA_LETTER_INDEX`) is always
     reserved for the "none of the above" option. The offset window must not

--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -186,32 +186,27 @@ def get_definitions(queries: list[WordQuery], language: str = "en") -> list[list
     return results
 
 
-def get_choice_probabilities(
-    probs, definitions: list[Definition], start_offset: int = 0,
-) -> list[float]:
+def get_choice_probabilities(probs, definitions: list[Definition]) -> list[float]:
     """Get probabilities for all choice letters including 'none of the above'.
 
     With a pruned decoder, logits (and therefore ``probs``) are already laid out
-    in answer-letter order. ``definitions[i]`` occupies letter
-    ``start_offset + i``; NOTA always lives at the fixed index
-    :data:`wsd.letters.NOTA_LETTER_INDEX`. The returned list has one entry per
-    definition followed by the NOTA probability.
+    in answer-letter order. ``definitions[i]`` occupies letter ``i``; NOTA
+    always lives at the fixed index :data:`wsd.letters.NOTA_LETTER_INDEX`. The
+    returned list has one entry per definition followed by the NOTA probability.
     """
-    choice_probs = [float(probs[start_offset + i]) for i in range(len(definitions))]
+    choice_probs = [float(probs[i]) for i in range(len(definitions))]
     choice_probs.append(float(probs[NOTA_LETTER_INDEX]))  # "none of the above"
     return choice_probs
 
 
 def _result_from_probs(
-    probs, definitions: list[Definition], start_offset: int = 0,
+    probs, definitions: list[Definition],
 ) -> DisambiguationResult:
     """Pick the best choice from ``probs`` and package it as a result.
 
-    NOTA is indexed at ``len(definitions)`` in the ``choice_probs`` list (it's
-    the appended last entry), not at :data:`NOTA_LETTER_INDEX`; confidence is
-    renormalized over the valid choices only.
+    Confidence is renormalized over the valid choices only.
     """
-    choice_probs = get_choice_probabilities(probs, definitions, start_offset)
+    choice_probs = get_choice_probabilities(probs, definitions)
     best_choice_idx = choice_probs.index(max(choice_probs))
     total_prob = sum(choice_probs)
     normalized_score = choice_probs[best_choice_idx] / total_prob if total_prob > 0 else 0.0
@@ -234,19 +229,16 @@ def disambiguate_word(
     word: str,
     marked_sentence: str,
     definitions: list[Definition],
-    start_offset: int = 0,
 ) -> DisambiguationResult:
     """Use ModernBERT to disambiguate word sense given context and definitions"""
     results = disambiguate_word_batch(
         [DisambiguationInput(word=word, marked_sentence=marked_sentence, definitions=definitions)],
-        start_offset=start_offset,
     )
     return results[0]
 
 
 def disambiguate_word_batch(
-        batch_data: list[DisambiguationInput],
-        start_offset: int = 0,
+    batch_data: list[DisambiguationInput],
 ) -> list[DisambiguationResult]:
     """
     Batch version of disambiguate_word that processes multiple words in parallel.
@@ -279,16 +271,13 @@ def disambiguate_word_batch(
             inp.marked_sentence,
             inp.definitions,
             components.tokenizer,
-            start_offset=start_offset,
         )
         for _, inp in valid
     ]
     batch_results = unmask_token_batch(prompts)
 
     for (i, inp), unmask_result in zip(valid, batch_results, strict=True):
-        results[i] = _result_from_probs(
-            unmask_result.probabilities, inp.definitions, start_offset=start_offset,
-        )
+        results[i] = _result_from_probs(unmask_result.probabilities, inp.definitions)
     return results
 
 


### PR DESCRIPTION
## Summary
- Only the deleted `bias_probe` passed non-zero `start_offset`. Inference always passes 0, so drop the parameter from `disambiguate_word`, `disambiguate_word_batch`, `get_choice_probabilities`, and `_result_from_probs`.
- Training still randomizes `start_offset` on `create_multiple_choice_prompt` (per-example offset breaks A-letter bias), so the parameter stays on `prompt.py`.
- Retarget the `prompt.py` docstring at training's randomization; the old wording pointed at the now-gone bias probe.

## Test plan
- [x] `ruff check` passes
- [ ] CI test suite green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure API cleanup and minor indexing simplification in WSD inference; behavior should be unchanged as inference previously always passed `start_offset=0`.
> 
> **Overview**
> Removes the unused `start_offset` parameter from the inference/disambiguation path (`disambiguate_word`, `disambiguate_word_batch`, `_result_from_probs`, and `get_choice_probabilities`), simplifying how answer-letter probabilities are indexed (always `definitions[i]` → letter `i`, with NOTA at `NOTA_LETTER_INDEX`).
> 
> Keeps `start_offset` support in `create_multiple_choice_prompt` for training-time randomization, and updates its docstring to reflect training randomization vs. inference always using `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25cc9fd0ccf9c9d581053a3eaf5b327212de2163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified word sense disambiguation probability indexing and removed unnecessary parameters from internal functions, streamlining the API while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->