### PR TITLE
cleanup: replace _dataclasses_to_dict with dataclasses.asdict

### DIFF
--- a/wsd/server.py
+++ b/wsd/server.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from dataclasses import asdict
 from datetime import UTC, datetime
 
 from starlette.applications import Starlette
@@ -25,17 +26,6 @@ logging.basicConfig(
 )
 
 templates = Jinja2Templates(directory=os.path.dirname(__file__))
-
-
-def _dataclasses_to_dict(obj):
-    if hasattr(obj, '__dataclass_fields__'):
-        return {field.name: _dataclasses_to_dict(getattr(obj, field.name))
-                for field in obj.__dataclass_fields__.values()}
-    elif isinstance(obj, list):
-        return [_dataclasses_to_dict(item) for item in obj]
-    elif isinstance(obj, dict):
-        return {key: _dataclasses_to_dict(value) for key, value in obj.items()}
-    return obj
 
 
 async def http_exception_handler(request: Request, exc: Exception):
@@ -68,7 +58,7 @@ async def disambiguate_request(request: Request):
             "wordnet_url": WORDNET_URL,
         })
     else:
-        return JSONResponse(_dataclasses_to_dict(result))
+        return JSONResponse(asdict(result))
 
 
 async def index_request(request: Request):


### PR DESCRIPTION
## Summary
- `_dataclasses_to_dict` reimplemented `dataclasses.asdict`. The output from `disambiguate()` is a `WordSenseDisambiguation` dataclass whose fields are lists of dataclasses with primitive leaves — exactly what `asdict` handles.
- 10-line helper → 1 stdlib import.

## Test plan
- [x] `ruff check` passes
- [ ] CI test suite green (`test_server.py` exercises the JSON response path)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup limited to JSON serialization of the `/disambiguate` response; behavior should be equivalent but could change edge-case serialization for non-dataclass/complex fields.
> 
> **Overview**
> Replaces the custom `_dataclasses_to_dict` helper with the standard library `dataclasses.asdict` when returning the JSON response from `disambiguate_request`.
> 
> This removes bespoke recursive serialization logic and relies on stdlib behavior for converting the `disambiguate()` result dataclass into a JSON-ready dict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0570ac6397f0594beed61f908e861b4ace0891b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->