### PR TITLE
cleanup: drop _validate_response_length + APIResponseError

### DIFF
--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -22,12 +22,6 @@ logger = logging.getLogger(__name__)
 NO_DEFINITIONS_FOUND = "No definitions found"
 
 
-class APIResponseError(ValueError):
-    """Raised when API response doesn't match expected format"""
-    def __init__(self, received: int, expected: int):
-        super().__init__(f"API response has {received} items but expected {expected} queries")
-
-
 @dataclass
 class WordQuery:
     """Query for word definitions"""
@@ -97,12 +91,6 @@ def get_spacy_pipeline(language: str = "en"):
     raise ValueError(msg)
 
 
-def _validate_response_length(results: list, queries: list[WordQuery]) -> None:
-    """Validate that API response has correct number of items"""
-    if len(results) < len(queries):
-        raise APIResponseError(received=len(results), expected=len(queries))
-
-
 def _get_definitions_raw(queries: list[WordQuery], language: str = "en") -> list[list[Definition]]:
     """
     Internal function to fetch definitions for multiple words using the batch endpoint.
@@ -126,32 +114,37 @@ def _get_definitions_raw(queries: list[WordQuery], language: str = "en") -> list
 
     try:
         response = requests.post(url, json=payload, timeout=30)
-
-        if response.status_code != 200:
-            logger.warning("WordNet API returned status code %s", response.status_code)
-            return [[] for _ in queries]
-
-        data = response.json()
-
-        # Parse response and maintain order. Definitions are kept in the order
-        # returned by the API — typically WordNet's frequency order — so the
-        # more common senses land on earlier letter slots.
-        results = []
-        for item in data.get("data", []):
-            definitions = [
-                Definition(synset_id=synset_id, definition=definition_text)
-                for synset_id, definition_text in item.get("definitions", {}).items()
-            ]
-            results.append(definitions)
-
-        # Validate response has correct number of items
-        _validate_response_length(results, queries)
-
-    except (requests.RequestException, APIResponseError) as e:
+    except requests.RequestException as e:
         logger.warning("WordNet batch request to %s failed: %s", url, e)
         return [[] for _ in queries]
-    else:
-        return results
+
+    if response.status_code != 200:
+        logger.warning("WordNet API returned status code %s", response.status_code)
+        return [[] for _ in queries]
+
+    try:
+        data = response.json()
+    except requests.RequestException as e:
+        logger.warning("WordNet API returned non-JSON body: %s", e)
+        return [[] for _ in queries]
+
+    # Parse response and maintain order. Definitions are kept in the order
+    # returned by the API — typically WordNet's frequency order — so the
+    # more common senses land on earlier letter slots.
+    results = [
+        [
+            Definition(synset_id=synset_id, definition=definition_text)
+            for synset_id, definition_text in item.get("definitions", {}).items()
+        ]
+        for item in data.get("data", [])
+    ]
+
+    if len(results) < len(queries):
+        logger.warning(
+            "WordNet API returned %d items, expected %d", len(results), len(queries),
+        )
+        return [[] for _ in queries]
+    return results
 
 
 def get_definitions(queries: list[WordQuery], language: str = "en") -> list[list[Definition]]:


### PR DESCRIPTION
## Summary
- `_validate_response_length` existed only to satisfy ruff's TRY301 (raise inside try that catches the same exception). `APIResponseError` existed only as the exception that helper raised. Both were internal scaffolding around a request/parse flow.
- Restructure so each failure mode (network error, non-200 status, non-JSON body, short response) logs and returns the empty-list fallback directly. No nested raise, no single-use exception class.
- Status check still runs before `response.json()`, so the test case in `test_get_definitions_api_error` (500 with no body) still short-circuits at the status check.

## Test plan
- [x] `ruff check` passes
- [ ] `test_get_definitions_api_error` green on CI (status 500 → empty list per query)
- [ ] `test_get_definitions_success` green on CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to error handling and parsing of an external WordNet API response; behavior stays conservative by falling back to empty results on more error cases.
> 
> **Overview**
> Simplifies WordNet batch definition fetching by removing the internal `APIResponseError`/`_validate_response_length` scaffolding and restructuring `_get_definitions_raw` to handle each failure mode inline.
> 
> Network errors, non-200 responses, non-JSON bodies, and short responses now log a warning and return an empty-per-query fallback directly, while successful responses are parsed via a single list-comprehension and then length-checked before returning results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57081bde540350c0a8671905b286d765924d190f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->