### PR TITLE
refactor: collapse NOTA branch in _update_tokens_with_results

### DIFF
--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -347,15 +347,11 @@ def _update_tokens_with_results(
 ) -> None:
     """Update tokens with disambiguation results"""
     for token_idx, result in zip(valid_indices, predictions, strict=True):
-        # Handle "none of the above" case
-        if result.definition == NONE_OF_THE_ABOVE:
-            tokens[token_idx].synset_id = None
-            tokens[token_idx].synset_definition = None
-            tokens[token_idx].confidence = result.confidence
-        else:
+        tokens[token_idx].confidence = result.confidence
+        # NOTA → leave synset_id/synset_definition at their dataclass defaults (None).
+        if result.definition != NONE_OF_THE_ABOVE:
             tokens[token_idx].synset_id = result.synset_id
             tokens[token_idx].synset_definition = result.definition
-            tokens[token_idx].confidence = result.confidence
 
 
 def _extract_entities(doc) -> list[Entity]:


### PR DESCRIPTION
## Summary
- `_update_tokens_with_results` wrote `confidence` in both branches and wrote `synset_id = None` / `synset_definition = None` in the NOTA branch, but those fields default to `None` on `DisambiguatedToken`. Hoist the unconditional write and drop the dead-default writes.
- Net: 7 removed / 3 added in one function; keeps all existing helpers intact.

## Test plan
- [x] `ruff check wsd/word_sense_disambiguation.py`
- [ ] Existing unit tests still pass