### PR TITLE
refactor(training): extract _random_start_offset helper

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -84,6 +84,18 @@ class TrainingExample:
     prompt: str
 
 
+def _random_start_offset(n_definitions: int) -> int:
+    """Random letter offset that keeps the options block clear of the NOTA slot.
+
+    Training spreads the correct answer across the whole letter range so the
+    model doesn't learn "correct answer clusters near A". The offset window
+    must leave room for all definitions before NOTA's fixed slot at
+    :data:`wsd.letters.NOTA_LETTER_INDEX`.
+    """
+    max_offset = NOTA_LETTER_INDEX - n_definitions
+    return random.randint(0, max_offset) if max_offset > 0 else 0
+
+
 def create_examples_for_synset(
     synset: dict,
     word: str,
@@ -124,11 +136,6 @@ def create_examples_for_synset(
 
     # Create one example for each sentence
     letters = build_letters(tokenizer).letters
-    # Pick a random offset per sentence so the model sees correct answers
-    # spread across the whole letter range, not clustered near A. NOTA's slot
-    # at letters[NOTA_LETTER_INDEX] is fixed, so the options block must end
-    # before it.
-    max_offset = NOTA_LETTER_INDEX - len(shuffled_definitions)
     for sentence in synset["examples"]:
         try:
             marked_sentence = mark_word_in_sentence(sentence, word)
@@ -138,7 +145,7 @@ def create_examples_for_synset(
             # skip so training matches inference.
             continue
 
-        start_offset = random.randint(0, max_offset) if max_offset > 0 else 0
+        start_offset = _random_start_offset(len(shuffled_definitions))
         correct_letter = letters[start_offset + correct_shuffled_idx]
 
         prompt = create_multiple_choice_prompt(
@@ -227,11 +234,7 @@ def create_none_of_above_example(
     # The correct answer is "none of the above" — always the fixed NOTA letter.
     none_letter = build_letters(tokenizer).letters[NOTA_LETTER_INDEX]
 
-    # Random offset so NOTA examples also see the option block at varied
-    # positions — otherwise the model would learn "NOTA appears when options
-    # start at A" which is also a positional shortcut.
-    max_offset = NOTA_LETTER_INDEX - len(frequent_pos_definitions)
-    start_offset = random.randint(0, max_offset) if max_offset > 0 else 0
+    start_offset = _random_start_offset(len(frequent_pos_definitions))
 
     prompt = create_multiple_choice_prompt(
         word=word,


### PR DESCRIPTION
## Summary
- The `max_offset = NOTA_LETTER_INDEX - n; randint(0, max_offset) if >0 else 0` pattern was duplicated in `create_examples_for_synset` and `create_none_of_above_example`. Both compute a random start offset that keeps the options block clear of NOTA's fixed slot.
- Extract to a `_random_start_offset(n_definitions)` helper. The "why" (avoid A-letter bias, leave room for NOTA) now lives on the helper's docstring instead of being repeated at both call sites.
- RNG consumption is bit-identical: each caller still draws exactly one `randint` value per call, in the same order as before. Training output is unchanged.

## Test plan
- [x] `ruff check` passes
- [x] Manually verified that both callers draw the same `random.randint` calls in the same order (one per `create_examples_for_synset` sentence, one per `create_none_of_above_example` call)
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to training-example prompt construction; behavior should remain identical aside from centralizing the offset calculation.
> 
> **Overview**
> Extracts duplicated "random start offset" logic into `_random_start_offset(n_definitions)` in `training/train.py` to keep multiple-choice options from overlapping the fixed NOTA slot while still varying answer-letter positions.
> 
> Updates both `create_examples_for_synset` and `create_none_of_above_example` to call the helper instead of re-implementing the `max_offset`/`randint` calculation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfce5579cee9ed6a49da81167420510d99b43f1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->