### PR TITLE
refactor(server): split HTTPException and generic exception handlers

### DIFF
--- a/wsd/server.py
+++ b/wsd/server.py
@@ -28,16 +28,26 @@ logging.basicConfig(
 templates = Jinja2Templates(directory=os.path.dirname(__file__))
 
 
-async def http_exception_handler(request: Request, exc: Exception):
-    status_code = exc.status_code if hasattr(exc, 'status_code') else 500
+async def http_exception_handler(request: Request, exc: HTTPException):
     body = {
         "error": {
-            "status": status_code,
-            "message": exc.detail if hasattr(exc, 'detail') else str(exc),
-            "type": type(exc).__name__
-        }
+            "status": exc.status_code,
+            "message": exc.detail,
+            "type": type(exc).__name__,
+        },
     }
-    return JSONResponse(body, status_code=status_code)
+    return JSONResponse(body, status_code=exc.status_code)
+
+
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    body = {
+        "error": {
+            "status": 500,
+            "message": str(exc),
+            "type": type(exc).__name__,
+        },
+    }
+    return JSONResponse(body, status_code=500)
 
 
 async def disambiguate_request(request: Request):
@@ -100,5 +110,5 @@ middlewares = [
 app = Starlette(debug=True, routes=routes, middleware=middlewares,
                 exception_handlers={
                     HTTPException: http_exception_handler,
-                    Exception: http_exception_handler,
+                    Exception: unhandled_exception_handler,
                 })


### PR DESCRIPTION
## Summary
- `http_exception_handler` was registered for both `HTTPException` and generic `Exception`, so it had to `hasattr()`-guess whether `status_code` / `detail` existed.
- Split into two handlers: `http_exception_handler` reads `HTTPException` fields directly; `unhandled_exception_handler` reports 500 with `str(exc)`. No behavior change.

## Test plan
- [x] `ruff check wsd/server.py`
- [ ] Hit a 4xx (e.g. `GET /disambiguate` with no params) and a 5xx path; confirm response shape is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor isolated to error-response formatting/registration; main risk is minor behavior differences for non-HTTP exceptions (message/status) if clients relied on the previous fallback.
> 
> **Overview**
> Splits Starlette error handling into two dedicated handlers: `http_exception_handler` now only handles `HTTPException` and directly uses `status_code`/`detail`, while a new `unhandled_exception_handler` returns a consistent 500 JSON payload for all other exceptions.
> 
> Updates the app’s `exception_handlers` registration to route `Exception` to the new handler, removing the prior `hasattr`-based fallback logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad88b6bb0ca12a9907bd9317d112320b0fba9cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->