### PR TITLE
Two-stage slim Docker build for faster Cloud Run cold starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # Stage 1: install dependencies and download models.
 FROM python:3.12-slim AS builder
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1 \
+ENV PYTHONUNBUFFERED=1 \
     HF_HOME=/opt/hf-cache
 
 RUN python -m venv /opt/venv
@@ -32,6 +30,8 @@ assert tm == cm, f'CUDA major mismatch: torch {torch.version.cuda} vs {cupy}'"
 # venv layer, which the spaCy entity-linker KB is written into) stay identical
 # across code-only changes and registries/Cloud Run can reuse them.
 RUN python -c "import spacy; nlp = spacy.load('en_core_web_trf'); nlp.add_pipe('entityLinker'); nlp('Apple is a technology company.')"
+# The model name mirrors _DEFAULT_MODEL in wsd/masked_language_model.py; it is
+# repeated here so the download can run before the code copy (keep in sync).
 RUN python -c "from huggingface_hub import snapshot_download; snapshot_download('sign/ModernBERT-Large-Instruct-WSD')"
 
 # Copy application code
@@ -45,17 +45,24 @@ RUN python -m wsd.prime
 FROM python:3.12-slim
 
 ENV PYTHONUNBUFFERED=1 \
-    LOG_LEVEL=DEBUG \
+    LOG_LEVEL=INFO \
     HF_HOME=/opt/hf-cache \
     PATH="/opt/venv/bin:$PATH"
 
+# Run as a non-root user; --create-home gives runtime caches (e.g. cupy's
+# kernel cache in ~/.cupy) a writable location.
+RUN useradd --create-home --uid 1000 app
+
 # Largest and most stable layers first, so code-only rebuilds reuse them.
-COPY --from=builder /opt/venv /opt/venv
-COPY --from=builder /opt/hf-cache /opt/hf-cache
+COPY --from=builder --chown=app:app /opt/venv /opt/venv
+COPY --from=builder --chown=app:app /opt/hf-cache /opt/hf-cache
 
 WORKDIR /app
-COPY wsd/ ./wsd/
+COPY --chown=app:app wsd/ ./wsd/
+
+USER app
 
 # Command to run the application. exec makes uvicorn PID 1 so it receives
 # SIGTERM and can shut down gracefully (Cloud Run sends SIGTERM, then SIGKILL).
+# $PORT is provided by the runtime; Cloud Run sets it automatically.
 CMD ["sh", "-c", "exec python -m uvicorn wsd.server:app --host 0.0.0.0 --port $PORT"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+# Stage 1: install dependencies and download models.
+FROM python:3.12-slim AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
-    LOG_LEVEL=DEBUG
+    HF_HOME=/opt/hf-cache
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 WORKDIR /app
 
@@ -11,14 +15,47 @@ WORKDIR /app
 COPY pyproject.toml .
 RUN mkdir wsd && touch wsd/__init__.py && touch /app/README.md
 
-# Install Python dependencies & Accelerate spaCy with CUDA
-RUN pip install --no-cache-dir ".[web]" spacy[cuda12x]
+# Install Python dependencies. torch arrives via accelerate/spacy-transformers
+# with its CUDA runtime bundled as pip wheels, so no CUDA base image is needed.
+# cupy-cuda13x matches torch's bundled CUDA 13 and accelerates spaCy on GPU.
+RUN pip install --no-cache-dir ".[web]" cupy-cuda13x
+
+# torch is unpinned, so a future release may bundle a different CUDA major and
+# silently break the cupy pairing (spacy would fall back to CPU at runtime).
+# Fail the build instead. Works without a GPU.
+RUN python -c "import re, torch; from importlib.metadata import distributions; \
+cupy = next(d.metadata['Name'] for d in distributions() if d.metadata['Name'].startswith('cupy-cuda')); \
+tm = torch.version.cuda.split('.')[0]; cm = re.search('cuda([0-9]+)', cupy).group(1); \
+assert tm == cm, f'CUDA major mismatch: torch {torch.version.cuda} vs {cupy}'"
+
+# Download the models before the code copy, so these heavy layers (and the
+# venv layer, which the spaCy entity-linker KB is written into) stay identical
+# across code-only changes and registries/Cloud Run can reuse them.
+RUN python -c "import spacy; nlp = spacy.load('en_core_web_trf'); nlp.add_pipe('entityLinker'); nlp('Apple is a technology company.')"
+RUN python -c "from huggingface_hub import snapshot_download; snapshot_download('sign/ModernBERT-Large-Instruct-WSD')"
 
 # Copy application code
 COPY wsd/ ./wsd/
 
-# Prime the dependency cache
+# Everything is already downloaded, so this is a fast end-to-end check that
+# the model and pipeline actually run.
 RUN python -m wsd.prime
 
-# Command to run the application
-CMD python -m uvicorn wsd.server:app --host 0.0.0.0 --port $PORT
+# Stage 2: runtime image carrying only the venv, model caches, and app code.
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    LOG_LEVEL=DEBUG \
+    HF_HOME=/opt/hf-cache \
+    PATH="/opt/venv/bin:$PATH"
+
+# Largest and most stable layers first, so code-only rebuilds reuse them.
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /opt/hf-cache /opt/hf-cache
+
+WORKDIR /app
+COPY wsd/ ./wsd/
+
+# Command to run the application. exec makes uvicorn PID 1 so it receives
+# SIGTERM and can shut down gracefully (Cloud Run sends SIGTERM, then SIGKILL).
+CMD ["sh", "-c", "exec python -m uvicorn wsd.server:app --host 0.0.0.0 --port $PORT"]

--- a/wsd/prime.py
+++ b/wsd/prime.py
@@ -6,7 +6,8 @@ from wsd.masked_language_model import load_model
 # Make sure it does not interact with the wordnet
 os.environ["WORDNET_URL"] = "NONE"
 
-from wsd.word_sense_disambiguation import disambiguate_word, get_spacy_pipeline
+from wsd.spacy_utils import get_spacy_pipeline
+from wsd.word_sense_disambiguation import disambiguate_word
 
 # Download spaCy entities knowledge base (600MB~)
 print("Priming spaCy model...")

--- a/wsd/server.py
+++ b/wsd/server.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -15,7 +16,12 @@ from starlette.routing import Route
 from starlette.templating import Jinja2Templates
 
 from wsd.env import WORDNET_URL
-from wsd.word_sense_disambiguation import disambiguate
+from wsd.word_sense_disambiguation import (
+    activate_spacy_pipeline,
+    build_gpu_spacy_pipeline,
+    disambiguate,
+    warm_cpu_spacy_pipeline,
+)
 
 # Honor LOG_LEVEL from the environment so the Dockerfile (or a local operator)
 # can dial in verbosity without touching code. Defaulting to INFO means our
@@ -108,14 +114,26 @@ middlewares = [
     )
 ]
 
+async def _swap_spacy_to_gpu():
+    gpu_nlp = await asyncio.to_thread(build_gpu_spacy_pipeline)
+    if gpu_nlp is not None:
+        # Runs in the event loop thread, between requests, so the backend flip
+        # and the pipeline swap are atomic with respect to request handling.
+        activate_spacy_pipeline("en", gpu_nlp)
+
+
 @asynccontextmanager
 async def lifespan(app: Starlette):
-    """Run the full pipeline once before serving traffic, so model loading and
-    GPU kernel compilation (~6s for spaCy's first call) happen at startup
-    instead of on the first request."""
+    """Warm up before serving traffic: load a CPU spaCy pipeline and the WSD
+    model so requests can be answered immediately, while the GPU spaCy
+    pipeline compiles its kernels in a worker thread and swaps in once warm
+    (~10s after start)."""
     logging.getLogger(__name__).info("Warming up the pipeline...")
+    warm_cpu_spacy_pipeline()
     disambiguate("bank")
+    gpu_swap = asyncio.create_task(_swap_spacy_to_gpu())
     yield
+    gpu_swap.cancel()
 
 
 app = Starlette(debug=True, routes=routes, middleware=middlewares,

--- a/wsd/server.py
+++ b/wsd/server.py
@@ -115,13 +115,19 @@ async def lifespan(app: Starlette):
     """Warm up before serving traffic: load a CPU spaCy pipeline and the WSD
     model so requests can be answered immediately, while the GPU spaCy
     pipeline compiles its kernels in a worker thread and swaps in once warm
-    (~10s after start)."""
-    logging.getLogger(__name__).info("Warming up the pipeline...")
-    warm_cpu_spacy_pipeline()
-    disambiguate("bank")
-    gpu_swap = asyncio.create_task(swap_spacy_to_gpu())
+    (~10s after start).
+
+    Set WSD_WARMUP=0 to skip (e.g. tests that need the server up instantly);
+    models then load lazily on the first request, as before."""
+    gpu_swap = None
+    if os.environ.get("WSD_WARMUP", "1") != "0":
+        logging.getLogger(__name__).info("Warming up the pipeline...")
+        warm_cpu_spacy_pipeline()
+        disambiguate("bank")
+        gpu_swap = asyncio.create_task(swap_spacy_to_gpu())
     yield
-    gpu_swap.cancel()
+    if gpu_swap is not None:
+        gpu_swap.cancel()
 
 
 app = Starlette(debug=True, routes=routes, middleware=middlewares,

--- a/wsd/server.py
+++ b/wsd/server.py
@@ -16,12 +16,8 @@ from starlette.routing import Route
 from starlette.templating import Jinja2Templates
 
 from wsd.env import WORDNET_URL
-from wsd.word_sense_disambiguation import (
-    activate_spacy_pipeline,
-    build_gpu_spacy_pipeline,
-    disambiguate,
-    warm_cpu_spacy_pipeline,
-)
+from wsd.spacy_utils import swap_spacy_to_gpu, warm_cpu_spacy_pipeline
+from wsd.word_sense_disambiguation import disambiguate
 
 # Honor LOG_LEVEL from the environment so the Dockerfile (or a local operator)
 # can dial in verbosity without touching code. Defaulting to INFO means our
@@ -114,14 +110,6 @@ middlewares = [
     )
 ]
 
-async def _swap_spacy_to_gpu():
-    gpu_nlp = await asyncio.to_thread(build_gpu_spacy_pipeline)
-    if gpu_nlp is not None:
-        # Runs in the event loop thread, between requests, so the backend flip
-        # and the pipeline swap are atomic with respect to request handling.
-        activate_spacy_pipeline("en", gpu_nlp)
-
-
 @asynccontextmanager
 async def lifespan(app: Starlette):
     """Warm up before serving traffic: load a CPU spaCy pipeline and the WSD
@@ -131,7 +119,7 @@ async def lifespan(app: Starlette):
     logging.getLogger(__name__).info("Warming up the pipeline...")
     warm_cpu_spacy_pipeline()
     disambiguate("bank")
-    gpu_swap = asyncio.create_task(_swap_spacy_to_gpu())
+    gpu_swap = asyncio.create_task(swap_spacy_to_gpu())
     yield
     gpu_swap.cancel()
 

--- a/wsd/server.py
+++ b/wsd/server.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from contextlib import asynccontextmanager
 from dataclasses import asdict
 from datetime import UTC, datetime
 
@@ -107,7 +108,18 @@ middlewares = [
     )
 ]
 
+@asynccontextmanager
+async def lifespan(app: Starlette):
+    """Run the full pipeline once before serving traffic, so model loading and
+    GPU kernel compilation (~6s for spaCy's first call) happen at startup
+    instead of on the first request."""
+    logging.getLogger(__name__).info("Warming up the pipeline...")
+    disambiguate("bank")
+    yield
+
+
 app = Starlette(debug=True, routes=routes, middleware=middlewares,
+                lifespan=lifespan,
                 exception_handlers={
                     HTTPException: http_exception_handler,
                     Exception: unhandled_exception_handler,

--- a/wsd/spacy_utils.py
+++ b/wsd/spacy_utils.py
@@ -1,0 +1,101 @@
+"""spaCy pipeline management: lazy loading, CPU/GPU backends, and the
+serve-on-CPU-then-swap-to-GPU warmup used by the web server."""
+import asyncio
+import logging
+import threading
+
+import spacy
+from thinc.api import use_ops
+
+logger = logging.getLogger(__name__)
+
+_PIPELINE_MODELS = {
+    'en': 'en_core_web_trf',
+    # Add more language models as needed
+}
+# language -> (pipeline, thinc backend it was built on: "numpy" or "cupy").
+# Every call must scope `use_ops(backend)`: input tensors are created on the
+# backend active in the *calling* context, which has to match the device the
+# pipeline's weights live on, and context state does not survive across
+# threads or asyncio tasks.
+_pipelines: dict[str, tuple[spacy.language.Language, str]] = {}
+_pipeline_lock = threading.Lock()
+
+
+def _load_pipeline(language: str) -> spacy.language.Language:
+    if language not in _PIPELINE_MODELS:
+        msg = f"Language '{language}' not supported"
+        raise ValueError(msg)
+    nlp = spacy.load(_PIPELINE_MODELS[language])
+    nlp.add_pipe("entityLinker", last=True)
+    return nlp
+
+
+def _get_pipeline_entry(language: str) -> tuple[spacy.language.Language, str]:
+    entry = _pipelines.get(language)
+    if entry is None:
+        with _pipeline_lock:
+            entry = _pipelines.get(language)
+            if entry is None:
+                gpu_activated = spacy.prefer_gpu()
+                logger.info("spaCy GPU activated: %s", gpu_activated)
+                entry = (_load_pipeline(language), "cupy" if gpu_activated else "numpy")
+                _pipelines[language] = entry
+    return entry
+
+
+def get_spacy_pipeline(language: str = "en") -> spacy.language.Language:
+    """Get the current spaCy pipeline for a language, loading it on first use.
+
+    Runs on GPU when one is available (requires cupy); falls back to CPU
+    otherwise.
+    """
+    return _get_pipeline_entry(language)[0]
+
+
+def run_spacy_pipeline(text: str, language: str = "en"):
+    """Run the pipeline on a text, on the backend the pipeline was built for."""
+    nlp, backend = _get_pipeline_entry(language)
+    with use_ops(backend):
+        return nlp(text)
+
+
+def warm_cpu_spacy_pipeline(language: str = "en") -> None:
+    """Load and warm a CPU pipeline (~2.5s) so requests can be served
+    immediately, without paying the GPU pipeline's one-time ~6s kernel
+    compilation first."""
+    with _pipeline_lock:
+        if language not in _pipelines:
+            with use_ops("numpy"):
+                cpu_nlp = _load_pipeline(language)
+                cpu_nlp("bank")
+            _pipelines[language] = (cpu_nlp, "numpy")
+
+
+def _build_gpu_spacy_pipeline(language: str = "en"):
+    """Build and warm a GPU pipeline; returns None when no GPU is available.
+
+    Heavy (one-time ~6s CUDA kernel compilation) — run it in a worker thread.
+    """
+    if not spacy.prefer_gpu():
+        logger.info("No GPU available for spaCy; staying on CPU")
+        return None
+    gpu_nlp = _load_pipeline(language)
+    # entityLinker stays on CPU and its sqlite connection is a process-wide
+    # singleton bound to the serving thread, so it must not run here; the
+    # transformer stack is what needs the one-time kernel compilation.
+    with gpu_nlp.select_pipes(disable=["entityLinker"]):
+        gpu_nlp("bank")
+    return gpu_nlp
+
+
+async def swap_spacy_to_gpu(language: str = "en") -> None:
+    """Build and warm the GPU pipeline in a worker thread, then publish it.
+
+    The publish runs back on the event loop, between requests, so the swap is
+    atomic with respect to request handling.
+    """
+    gpu_nlp = await asyncio.to_thread(_build_gpu_spacy_pipeline, language)
+    if gpu_nlp is not None:
+        _pipelines[language] = (gpu_nlp, "cupy")
+        logger.info("spaCy pipeline swapped to GPU")

--- a/wsd/test_server.py
+++ b/wsd/test_server.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import subprocess
 import time
@@ -37,12 +38,14 @@ class ServerProcess:
         self.process = None
 
     def start(self):
+        # WSD_WARMUP=0 skips the startup warmup so the server is listening
+        # immediately; models load lazily on the first request instead.
         self.process = subprocess.Popen([
             "uvicorn", "wsd.server:app",
             "--host", self.host,
             "--port", str(self.port),
             "--log-level", "warning"
-        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env={**os.environ, "WSD_WARMUP": "0"})
 
         if not wait_for_port(self.host, self.port, timeout=10):
             stdout, stderr = self.process.communicate(timeout=2)

--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -82,6 +82,10 @@ def get_spacy_pipeline(language: str = "en"):
         # Add more language models as needed
     }
     if language in model_map:
+        # Run the pipeline on GPU when one is available (requires cupy);
+        # falls back to CPU otherwise.
+        gpu_activated = spacy.prefer_gpu()
+        logger.info("spaCy GPU activated: %s", gpu_activated)
         nlp = spacy.load(model_map[language])
         nlp.add_pipe("entityLinker", last=True)
         return nlp

--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -1,9 +1,10 @@
 import logging
+import threading
 from dataclasses import dataclass
-from functools import cache
 
 import requests
 import spacy
+from thinc.api import use_ops
 
 from wsd.env import WORDNET_URL
 from wsd.letters import NOTA_LETTER_INDEX
@@ -74,24 +75,88 @@ class WordSenseDisambiguation:
     entities: list[Entity]
 
 
-@cache
-def get_spacy_pipeline(language: str = "en"):
-    """Get or load and cache spaCy model for given language"""
-    model_map = {
-        'en': 'en_core_web_trf',
-        # Add more language models as needed
-    }
-    if language in model_map:
-        # Run the pipeline on GPU when one is available (requires cupy);
-        # falls back to CPU otherwise.
-        gpu_activated = spacy.prefer_gpu()
-        logger.info("spaCy GPU activated: %s", gpu_activated)
-        nlp = spacy.load(model_map[language])
-        nlp.add_pipe("entityLinker", last=True)
-        return nlp
+_PIPELINE_MODELS = {
+    'en': 'en_core_web_trf',
+    # Add more language models as needed
+}
+# language -> (pipeline, thinc backend it was built on: "numpy" or "cupy").
+# Every call must scope `use_ops(backend)`: input tensors are created on the
+# backend active in the *calling* context, which has to match the device the
+# pipeline's weights live on, and context state does not survive across
+# threads or asyncio tasks.
+_pipelines: dict[str, tuple[spacy.language.Language, str]] = {}
+_pipeline_lock = threading.Lock()
 
-    msg = f"Language '{language}' not supported"
-    raise ValueError(msg)
+
+def _load_pipeline(language: str) -> spacy.language.Language:
+    if language not in _PIPELINE_MODELS:
+        msg = f"Language '{language}' not supported"
+        raise ValueError(msg)
+    nlp = spacy.load(_PIPELINE_MODELS[language])
+    nlp.add_pipe("entityLinker", last=True)
+    return nlp
+
+
+def get_spacy_pipeline(language: str = "en"):
+    """Get the current spaCy pipeline for a language, loading it on first use.
+
+    Runs on GPU when one is available (requires cupy); falls back to CPU
+    otherwise.
+    """
+    entry = _pipelines.get(language)
+    if entry is None:
+        with _pipeline_lock:
+            entry = _pipelines.get(language)
+            if entry is None:
+                gpu_activated = spacy.prefer_gpu()
+                logger.info("spaCy GPU activated: %s", gpu_activated)
+                entry = (_load_pipeline(language), "cupy" if gpu_activated else "numpy")
+                _pipelines[language] = entry
+    return entry[0]
+
+
+def run_spacy_pipeline(text: str, language: str = "en"):
+    """Run the pipeline on a text, on the backend the pipeline was built for."""
+    get_spacy_pipeline(language)
+    nlp, backend = _pipelines[language]
+    with use_ops(backend):
+        return nlp(text)
+
+
+def warm_cpu_spacy_pipeline(language: str = "en") -> None:
+    """Load and warm a CPU pipeline (~2.5s) so requests can be served
+    immediately, without paying the GPU pipeline's one-time ~6s kernel
+    compilation first."""
+    with _pipeline_lock:
+        if language not in _pipelines:
+            with use_ops("numpy"):
+                cpu_nlp = _load_pipeline(language)
+                cpu_nlp("bank")
+            _pipelines[language] = (cpu_nlp, "numpy")
+
+
+def build_gpu_spacy_pipeline(language: str = "en"):
+    """Build and warm a GPU pipeline; returns None when no GPU is available.
+
+    Heavy (one-time ~6s CUDA kernel compilation) — run it in a worker thread
+    and publish the result with activate_spacy_pipeline.
+    """
+    if not spacy.prefer_gpu():
+        logger.info("No GPU available for spaCy; staying on CPU")
+        return None
+    gpu_nlp = _load_pipeline(language)
+    # entityLinker stays on CPU and its sqlite connection is a process-wide
+    # singleton bound to the serving thread, so it must not run here; the
+    # transformer stack is what needs the one-time kernel compilation.
+    with gpu_nlp.select_pipes(disable=["entityLinker"]):
+        gpu_nlp("bank")
+    return gpu_nlp
+
+
+def activate_spacy_pipeline(language: str, nlp) -> None:
+    """Publish a warmed GPU pipeline; subsequent requests run on it."""
+    _pipelines[language] = (nlp, "cupy")
+    logger.info("spaCy pipeline swapped to GPU")
 
 
 def _get_definitions_raw(queries: list[WordQuery], language: str = "en") -> list[list[Definition]]:
@@ -377,8 +442,7 @@ def _extract_entities(doc) -> list[Entity]:
 
 
 def disambiguate(text: str, language: str = "en") -> WordSenseDisambiguation:
-    nlp = get_spacy_pipeline(language)
-    doc = nlp(text)
+    doc = run_spacy_pipeline(text, language)
 
     # First pass: Create all base tokens and identify content words to disambiguate
     tokens, content_word_indices = _create_base_tokens(doc)

--- a/wsd/word_sense_disambiguation.py
+++ b/wsd/word_sense_disambiguation.py
@@ -1,10 +1,7 @@
 import logging
-import threading
 from dataclasses import dataclass
 
 import requests
-import spacy
-from thinc.api import use_ops
 
 from wsd.env import WORDNET_URL
 from wsd.letters import NOTA_LETTER_INDEX
@@ -15,6 +12,7 @@ from wsd.prompt import (
     create_marked_sentence,
     create_multiple_choice_prompt,
 )
+from wsd.spacy_utils import run_spacy_pipeline
 
 logger = logging.getLogger(__name__)
 
@@ -73,90 +71,6 @@ class DisambiguationInput:
 class WordSenseDisambiguation:
     tokens: list[DisambiguatedToken]
     entities: list[Entity]
-
-
-_PIPELINE_MODELS = {
-    'en': 'en_core_web_trf',
-    # Add more language models as needed
-}
-# language -> (pipeline, thinc backend it was built on: "numpy" or "cupy").
-# Every call must scope `use_ops(backend)`: input tensors are created on the
-# backend active in the *calling* context, which has to match the device the
-# pipeline's weights live on, and context state does not survive across
-# threads or asyncio tasks.
-_pipelines: dict[str, tuple[spacy.language.Language, str]] = {}
-_pipeline_lock = threading.Lock()
-
-
-def _load_pipeline(language: str) -> spacy.language.Language:
-    if language not in _PIPELINE_MODELS:
-        msg = f"Language '{language}' not supported"
-        raise ValueError(msg)
-    nlp = spacy.load(_PIPELINE_MODELS[language])
-    nlp.add_pipe("entityLinker", last=True)
-    return nlp
-
-
-def get_spacy_pipeline(language: str = "en"):
-    """Get the current spaCy pipeline for a language, loading it on first use.
-
-    Runs on GPU when one is available (requires cupy); falls back to CPU
-    otherwise.
-    """
-    entry = _pipelines.get(language)
-    if entry is None:
-        with _pipeline_lock:
-            entry = _pipelines.get(language)
-            if entry is None:
-                gpu_activated = spacy.prefer_gpu()
-                logger.info("spaCy GPU activated: %s", gpu_activated)
-                entry = (_load_pipeline(language), "cupy" if gpu_activated else "numpy")
-                _pipelines[language] = entry
-    return entry[0]
-
-
-def run_spacy_pipeline(text: str, language: str = "en"):
-    """Run the pipeline on a text, on the backend the pipeline was built for."""
-    get_spacy_pipeline(language)
-    nlp, backend = _pipelines[language]
-    with use_ops(backend):
-        return nlp(text)
-
-
-def warm_cpu_spacy_pipeline(language: str = "en") -> None:
-    """Load and warm a CPU pipeline (~2.5s) so requests can be served
-    immediately, without paying the GPU pipeline's one-time ~6s kernel
-    compilation first."""
-    with _pipeline_lock:
-        if language not in _pipelines:
-            with use_ops("numpy"):
-                cpu_nlp = _load_pipeline(language)
-                cpu_nlp("bank")
-            _pipelines[language] = (cpu_nlp, "numpy")
-
-
-def build_gpu_spacy_pipeline(language: str = "en"):
-    """Build and warm a GPU pipeline; returns None when no GPU is available.
-
-    Heavy (one-time ~6s CUDA kernel compilation) — run it in a worker thread
-    and publish the result with activate_spacy_pipeline.
-    """
-    if not spacy.prefer_gpu():
-        logger.info("No GPU available for spaCy; staying on CPU")
-        return None
-    gpu_nlp = _load_pipeline(language)
-    # entityLinker stays on CPU and its sqlite connection is a process-wide
-    # singleton bound to the serving thread, so it must not run here; the
-    # transformer stack is what needs the one-time kernel compilation.
-    with gpu_nlp.select_pipes(disable=["entityLinker"]):
-        gpu_nlp("bank")
-    return gpu_nlp
-
-
-def activate_spacy_pipeline(language: str, nlp) -> None:
-    """Publish a warmed GPU pipeline; subsequent requests run on it."""
-    _pipelines[language] = (nlp, "cupy")
-    logger.info("spaCy pipeline swapped to GPU")
 
 
 def _get_definitions_raw(queries: list[WordQuery], language: str = "en") -> list[list[Definition]]:


### PR DESCRIPTION
## Why

Cloud Run cold start is dominated by image download time. The image was built on `nvcr.io/nvidia/pytorch:26.03-py3`, which alone is 22.5GB of TensorRT/CUDA-toolkit/compilers the server never uses — total image 25.7GB.

## What

**Two-stage build on `python:3.12-slim`** — builder installs `.[web]` + `cupy-cuda13x` into a venv and downloads the models; the runtime stage carries only the venv, the HF cache, and the app code. **25.7GB → 8.2GB (3.1× smaller).**

- **No CUDA base image needed**: torch's pip wheels bundle the CUDA runtime (`nvidia-*-cu13`); Cloud Run injects the driver. Verified on GPU: `torch.cuda.is_available()` → True inside the image.
- **spaCy now actually uses the GPU**: `get_spacy_pipeline()` calls `spacy.prefer_gpu()` (previously `spacy[cuda12x]` was installed but nothing ever activated it, so spaCy always ran on CPU). Falls back to CPU gracefully when no GPU is present.
- **CUDA pairing guard**: torch is unpinned, so a future torch bumping its CUDA major would silently break cupy and drop spaCy to CPU. A build-time assert (no GPU needed) fails the build instead.
- **Layer stability for revision-to-revision reuse**: models download *before* `COPY wsd/`, so the heavy layers (venv ≈6GB incl. the entity-linker KB, HF cache ≈1.6GB) stay byte-identical across code-only changes — registries and Cloud Run nodes can reuse them between revisions. `wsd.prime` remains after the code copy as a fast (~5s) end-to-end verification.
- **Graceful shutdown**: CMD now `exec`s uvicorn so it runs as PID 1 and receives SIGTERM (previously `sh` swallowed it and every Cloud Run shutdown hit SIGKILL). Measured: `docker stop` 1.1s vs hitting the kill timeout before.

## Verification (local, NVIDIA GB10)

- Full build from a clean stage passes; CUDA pairing assert passes (`torch 13.0 / cupy-cuda13x`)
- `GET /disambiguate` → 200 with correct WSD tokens and entity links (Apple Inc. Q312, California, …)
- Log shows `spaCy GPU activated: True` with `--gpus all`, `False` without (graceful fallback)
- `docker top`: python is PID 1; `docker stop` returns in 1.1s
- Code-only rebuild: venv/model layers come back CACHED, prime re-runs in 5.2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches container runtime (non-root, signals), CUDA/cupy pairing, and request-path NLP backend swapping at startup; behavior changes on GPU vs CPU but includes build-time guards and test bypass for warmup.
> 
> **Overview**
> Replaces the **25GB NVIDIA PyTorch base image** with a **two-stage `python:3.12-slim` build** (~8GB): the builder installs `.[web]` plus **`cupy-cuda13x`**, pre-downloads spaCy/Hugging Face models **before** copying app code (stable cache layers), and asserts **torch vs cupy CUDA major** at build time. The runtime stage ships only the venv, model caches, and code, runs as a **non-root** user, and **`exec`s uvicorn** so SIGTERM reaches PID 1 for graceful shutdown.
> 
> **spaCy** moves into **`wsd/spacy_utils.py`**: lazy load with **`spacy.prefer_gpu()`** when cupy is available, **`use_ops`**-scoped inference, plus **startup warmup**—CPU pipeline first, then **background GPU build/swap**—wired through a Starlette **`lifespan`** hook (`WSD_WARMUP=0` skips it; integration tests set that). **`disambiguate`** now calls **`run_spacy_pipeline`** instead of inlined cached `get_spacy_pipeline`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 139729e3668da23f6910982aff303dc01350fd78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App can pre-warm NLP pipelines at startup and perform a background CPU→GPU swap for faster inference (can be disabled via env).
* **Chores**
  * Container build/runtime optimized to pre-download and cache model assets, reducing cold-start time.
  * Server startup adjusted so the process receives termination signals for graceful shutdown.
* **Tests**
  * Test startup adjusted to skip warm-up so server begins listening immediately during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->